### PR TITLE
Fix: [Dockerfile] ビルド時にキャッシュが効くよう構成変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,35 @@
+# サードパーティーライブラリのダウンロードを行うステージ
+# 念のため最終イメージに合わせて ubuntu20.04 にしておく
+# 中間イメージなので、サイズは（ビルドするマシンのディスク容量以外は）気にしなくて良い
+FROM ubuntu:20.04 AS thirdparty-downloader
 
-# Ubuntu 20.04 LTS をベースイメージとして利用
-FROM nvidia/cuda:11.4.1-runtime-ubuntu20.04
+# apt-get に対話的に設定確認されないための設定
+ENV DEBIAN_FRONTEND=noninteractive
 
-# タイムゾーンを東京に設定
-ENV TZ=Asia/Tokyo
-
-# アプリケーションをマウント
-ADD ./ /code
-WORKDIR /code/server
-
-# パッケージのインストール
-## DEBIAN_FRONTEND=noninteractive はダイヤログを無視するおまじない
+# パッケージ一覧更新、全体の更新
 RUN apt-get update -y && apt-get upgrade -y
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y aria2 gpg-agent p7zip-full python3.9 python3-pip
 
-# サードパーティーライブラリが必要とするパッケージのインストール
-RUN apt-get install -y ffmpeg libv4l-0 libxcb1 libva2 libmfx1 intel-media-va-driver-non-free
+# ダウンロード・展開に必要なパッケージのインストール
+RUN apt-get install -y --no-install-recommends \
+    aria2 \
+    binutils \
+    ca-certificates \
+    gpg-agent \
+    p7zip-full \
+    xz-utils
+
+# VCEEncC が依存する AMD AMF ライブラリをダウンロードし、展開
+# サードパーティーライブラリよりも更新されにくいので先にする
+RUN aria2c -x10 https://drivers.amd.com/drivers/linux/amdgpu-pro-21.30-1290604-ubuntu-20.04.tar.xz --referer=www.amd.com
+RUN tar xvf amdgpu-pro-21.30-1290604-ubuntu-20.04.tar.xz && rm amdgpu-pro-21.30-1290604-ubuntu-20.04.tar.xz && \
+    cd amdgpu-pro-21.30-1290604-ubuntu-20.04 && ar vx amf-amdgpu-pro_21.30-1290604_amd64.deb && tar xvf data.tar.xz && \
+    cp -r opt/amdgpu-pro/lib/x86_64-linux-gnu/libamfrt64.so.0.0.0 /usr/lib/x86_64-linux-gnu/libamfrt64.so
+RUN ln -s /usr/lib/x86_64-linux-gnu/libamfrt64.so /usr/lib/x86_64-linux-gnu/libamfrt64.so.1
 
 # サードパーティーライブラリをダウンロード
+WORKDIR /thirdparty
 RUN aria2c -x10 https://github.com/tsukumijima/KonomiTV/releases/download/v0.4.0/thirdparty.7z
-RUN 7z x -y thirdparty.7z && rm thirdparty.7z
+RUN 7z x -y thirdparty.7z
 
 # サードパーティーライブラリに実行権限を付与
 RUN chmod 755 ./thirdparty/FFmpeg/ffmpeg.elf && \
@@ -29,30 +39,72 @@ RUN chmod 755 ./thirdparty/FFmpeg/ffmpeg.elf && \
     chmod 755 ./thirdparty/tsreadex/tsreadex.elf && \
     chmod 755 ./thirdparty/VCEEncC/VCEEncC.elf
 
-# NVEncC が依存する NVENC ライブラリにシンボリックリンクを付与
-RUN ln -s /usr/lib/x86_64-linux-gnu/libnvcuvid.so.1 /usr/lib/x86_64-linux-gnu/libnvcuvid.so
-RUN ln -s /usr/lib/x86_64-linux-gnu/libnvidia-encode.so.1 /usr/lib/x86_64-linux-gnu/libnvidia-encode.so
+# client のビルド
+FROM node:16 AS client-builder
 
-# VCEEncC が依存する AMD AMF ライブラリをダウンロードし、シンボリックリンクを付与
-RUN aria2c -x10 https://drivers.amd.com/drivers/linux/amdgpu-pro-21.30-1290604-ubuntu-20.04.tar.xz --referer=www.amd.com
-RUN tar xvf amdgpu-pro-21.30-1290604-ubuntu-20.04.tar.xz && rm amdgpu-pro-21.30-1290604-ubuntu-20.04.tar.xz && \
-    cd amdgpu-pro-21.30-1290604-ubuntu-20.04 && ar vx amf-amdgpu-pro_21.30-1290604_amd64.deb && tar xvf data.tar.xz && \
-    cp -r opt/amdgpu-pro/lib/x86_64-linux-gnu/libamfrt64.so.0.0.0 /usr/lib/x86_64-linux-gnu/libamfrt64.so && \
-    cd ../ && rm -rf amdgpu-pro-21.30-1290604-ubuntu-20.04/
-RUN ln -s /usr/lib/x86_64-linux-gnu/libamfrt64.so /usr/lib/x86_64-linux-gnu/libamfrt64.so.1
+# 依存パッケージリストをコピー
+COPY ./client/package.json ./client/yarn.lock /code/client/
+WORKDIR /code/client
+RUN yarn
 
-# 依存パッケージのインストール
-## 仮想環境 (.venv) をプロジェクト直下に作成する
-ENV PIPENV_VENV_IN_PROJECT true
-RUN pip install pipenv
-RUN pipenv sync
+# アプリケーションをコピー
+COPY ./client /code/client
 
-# 不必要なパッケージを削除
-RUN apt-get -y remove aria2 p7zip-full && \
+# クライアントをビルド、/code/client/dist に成果物が作成される
+RUN yarn build
+
+# server のセットアップ兼実行時のイメージ
+# Ubuntu 20.04 LTS をベースイメージとして利用
+FROM nvidia/cuda:11.4.1-runtime-ubuntu20.04
+
+# タイムゾーンを東京に設定
+ENV TZ=Asia/Tokyo
+
+# apt-get に対話的に設定確認されないための設定
+ENV DEBIAN_FRONTEND=noninteractive
+
+# パッケージのインストール（実行時イメージなのでRUNの最後に掃除する）
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y --no-install-recommends \
+    python3.9 \
+    python3-pip \
+    ffmpeg \
+    libv4l-0 \
+    libxcb1 \
+    libva2 \
+    libmfx1 \
+    intel-media-va-driver-non-free && \
     apt-get -y autoremove && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/*
+
+# pipenv をインストール
+RUN pip install pipenv
+
+# NVEncC が依存する NVENC ライブラリにシンボリックリンクを付与
+RUN ln -s /usr/lib/x86_64-linux-gnu/libnvcuvid.so.1 /usr/lib/x86_64-linux-gnu/libnvcuvid.so
+RUN ln -s /usr/lib/x86_64-linux-gnu/libnvidia-encode.so.1 /usr/lib/x86_64-linux-gnu/libnvidia-encode.so
+
+# VCEEncC が依存する AMD AMF ライブラリにシンボリックリンクを付与
+COPY --from=thirdparty-downloader /usr/lib/x86_64-linux-gnu/libamfrt64.so* /usr/lib/x86_64-linux-gnu/
+
+# パッケージリストだけをコピー
+COPY ./server/Pipfile* /code/server/
+WORKDIR /code/server
+
+# 依存パッケージのインストール
+## 仮想環境 (.venv) をプロジェクト直下に作成する
+ENV PIPENV_VENV_IN_PROJECT true
+RUN pipenv sync
+
+# 残りのアプリケーションをコピー
+COPY ./server /code/server
+
+# ダウンロードしておいたサードパーティライブラリをコピー
+COPY --from=thirdparty-downloader /thirdparty/thirdparty /code/server/thirdparty
+
+# client の成果物をコピー（dist だけで良い）
+COPY --from=client-builder /code/client/dist /code/client/dist
 
 # データベースを必要な場合にアップグレードし、起動
 ENTRYPOINT pipenv run aerich upgrade && exec pipenv run serve


### PR DESCRIPTION
## 変更の種類
<!-- このプルリクエストではどのような変更が行われますか？ 該当するすべてのボックスに「x」を入力してください。 -->
- [ ] 不具合の修正
- [ ] 新しい機能の追加
- [x] 改善・リファクタリング（機能は追加されないが、動作やコードを改善する破壊的でない変更）

## チェックリスト:
<!-- 以下のすべての点に目を通し、該当するすべてのボックスに「x」を入力してください。 -->
- [x] [開発資料](https://mango-garlic-eff.notion.site/KonomiTV-90f4b25555c14b9ba0cf5498e6feb1c3) と [データベース設計](https://mango-garlic-eff.notion.site/KonomiTV-544e02334c89420fa24804ec70f46b6d) は読みましたか？
  - もともと自分用のメモですが、このプロジェクトの開発方針や設計などが記載されています。開発時の参考にしてください。
- [x] Git のコミットメッセージは開発資料に記載のフォーマットになっていますか？（重要）
  - このプロジェクト上のコミットメッセージは、基本的に全てこのフォーマットに従って記述されています（文字数は問いません）。
  - 正しいフォーマットになっていない場合、force push で必ずコミットメッセージを変更してから送信してください。
- [ ] このプロジェクトのコーディング規約に従ったコードになっていますか？
  - コーディング規約は開発資料に記載されています。
  - そもそもコーディング規約と言えるほど大層なものではありませんが、一度目を通しておいてください。
- [x] プルリクエストは master ブランチに送信されていますか？
  - release ブランチはリリースした時にしか更新されません。必ず master ブランチに送信してください。

※コーディング規約にDockerfileについて記載がないためチェックをつけていません。.editorconfigは守れてるはずです。

## 説明
<!-- このプルリクエストでの変更点を詳しく説明してください。 -->

ちょっとDockerfileの書き方解説のような部分もあるので長くなります。変更点は大きく以下の3点です。

1. マルチステージビルドの導入
2. 構成順序の変更
3. クライアントのビルドを追加

元の `Dockerfile` では `ADD ./ /code` が最初の方にあるため、ソースコード全体のどこかが変更されただけでそれ以降のレイヤーキャッシュが無効になっていました。また、ダウンロード＆展開のためにaria2やxzなどサーバの実行に必要のないツールがインストールされていました。Docker イメージはADD とか RUN のコマンドごとにレイヤーが構成されるため、あとで削除しても全体のイメージサイズは削減できません。
そこで、1. のマルチステージビルドを導入し、ダウンロード＆展開は別ステージのイメージで行い、成果物だけを最終的な実行イメージにコピーする形にしました。3. で追加したクライアントのビルドも、node.jsなどを別ステージのイメージでインストール（というかベースイメージから取ってきてますけど）しているので、最終的な実行イメージには.htmlや.jsなどの必要なもの以外含まれません。ちなみに、マルチステージビルドになっていると、buildx をインストールすることで並列ビルドをすることもできます（各ステージを並列にビルドしていく）。

また、2. の構成順序の変更というのは、docker build するとき、Dockerfile の上から順に見ていって、以前ビルドしたことがあるコマンドだけの場合（COPY/ADDの場合はコピーされるファイルに変更がない場合）、以前ビルドした際のレイヤーを使いまわします（レイヤーキャッシュ）。基本的には変更されにくいものを上に、変更されやすいものを下に書いていくと良いです。
例えば、ダウンロードではAMDのライブラリはそれほど更新されないですが、サードパーティライブラリはリリースごとには更新されます。なので、AMDのライブラリが先に処理するように変更しました。
また、`yarn` コマンドによる `node_modules` の作成や `pipenv sync` などでインストールされる依存ライブラリが変更になることはアプリケーションの更新に比べて頻度が低いはずです。そこで、依存パッケージ管理に使われるファイル（Pipfile, Pipfile.lock, package.json, yarn.lock）だけをCOPYし、依存パッケージのインストールを行い、その後あらためてアプリケーション全体のコピーを行っています。

## 動機とコンテキスト
<!-- この変更はなぜ必要ですか？どのような問題が解決されますか？ -->
<!-- この変更で未解決の Issue が修正される場合は、ここにリンクを貼ってください。 -->

既存の Dockerfile ではビルド時のレイヤーキャッシュが効かないような書き方になっており、コードの変更がある度に `docker build` で各種ダウンロードなどが走って非効率的であったため、改善した。
また、client ディレクトリ以下が事前に `yarn build` してあることが前提になっており、更新忘れが発生する可能性があったので、docker 内でクライアントもビルドするようにした。