### PR TITLE
Fix: [Dockerfile] VCEEncC が動作するよう Dockerfile を変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,11 +63,12 @@ RUN apt-get update -y && apt-get install -y curl gpg-agent && \
     echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics-keyring.gpg] https://repositories.intel.com/graphics/ubuntu focal main' > /etc/apt/sources.list.d/intel-graphics.list && \
     echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-keyring.gpg] https://repo.radeon.com/amdgpu/22.20.1/ubuntu jammy main' > /etc/apt/sources.list.d/amdgpu.list && \
     echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-keyring.gpg] https://repo.radeon.com/amdgpu/22.20.1/ubuntu jammy proprietary' > /etc/apt/sources.list.d/amdgpu-proprietary.list && \
+    echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/rocm-keyring.gpg] https://repo.radeon.com/rocm/apt/5.2 ubuntu main' > /etc/apt/sources.list.d/rocm.list && \
     apt-get update -y && apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
         libfontconfig1 libfreetype6 libfribidi0 \
         intel-media-va-driver-non-free intel-opencl-icd libigfxcmrt7 libmfx1 libmfx-gen1.2 libva-drm2 libva-x11-2 ocl-icd-opencl-dev \
-        amf-amdgpu-pro libamdenc-amdgpu-pro libdrm2-amdgpu vulkan-amdgpu-pro && \
+        amf-amdgpu-pro libamdenc-amdgpu-pro libdrm2-amdgpu vulkan-amdgpu-pro rocm-opencl-runtime opencl-legacy-amdgpu-pro-icd && \
     apt-get -y autoremove && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/* && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,9 +73,6 @@ RUN apt-get update -y && apt-get install -y curl gpg-agent && \
     rm -rf /var/lib/apt/lists/* && \
     rm -rf /tmp/*
 
-# AMD VCE 関連のライブラリは /opt/amdgpu-pro/lib/x86_64-linux-gnu/ 以下にインストールされるので、/usr/lib/x86_64-linux-gnu/ へコピー
-RUN cp -a /opt/amdgpu-pro/lib/x86_64-linux-gnu/* /usr/lib/x86_64-linux-gnu/
-
 # ダウンロードしておいたサードパーティライブラリをコピー
 COPY --from=thirdparty-downloader /thirdparty /code/server/thirdparty
 


### PR DESCRIPTION
## 変更の種類
<!-- このプルリクエストではどのような変更が行われますか？ 該当するすべてのボックスに「x」を入力してください。 -->
- [x] 不具合の修正
- [ ] 新しい機能の追加
- [ ] 改善・リファクタリング（機能は追加されないが、動作やコードを改善する破壊的でない変更）

## チェックリスト:
<!-- 以下のすべての点に目を通し、該当するすべてのボックスに「x」を入力してください。 -->
- [x] [開発資料](https://mango-garlic-eff.notion.site/KonomiTV-90f4b25555c14b9ba0cf5498e6feb1c3) と [データベース設計](https://mango-garlic-eff.notion.site/KonomiTV-544e02334c89420fa24804ec70f46b6d) は読みましたか？
  - もともと自分用のメモですが、このプロジェクトの開発方針や設計などが記載されています。開発時の参考にしてください。
- [x] Git のコミットメッセージは開発資料に記載のフォーマットになっていますか？（重要）
  - このプロジェクト上のコミットメッセージは、基本的に全てこのフォーマットに従って記述されています（文字数は問いません）。
  - 正しいフォーマットになっていない場合、force push で必ずコミットメッセージを変更してから送信してください。
- [ ] このプロジェクトのコーディング規約に従ったコードになっていますか？
  - コーディング規約は開発資料に記載されています。
  - そもそもコーディング規約と言えるほど大層なものではありませんが、一度目を通しておいてください。
- [x] プルリクエストは master ブランチに送信されていますか？
  - release ブランチはリリースした時にしか更新されません。必ず master ブランチに送信してください。

## 説明
docker内でvceenccの実行に必要なパッケージが不足していたのを解消します。

また、amdgpu関連のパッケージ導入後、下記設定ファイルが自動で追加されるため、soの/usr/lib/x86_64-linux-gnu/へのコピーは不要と考え削除します。
```
$ cat /etc/ld.so.conf.d/10-amdgpu-pro.conf 
/opt/amdgpu-pro/lib/x86_64-linux-gnu
/opt/amdgpu-pro/lib/i386-linux-gnu
$ cat /etc/ld.so.conf.d/10-rocm-opencl.conf 
/opt/rocm-5.2.0/lib
$ cat /etc/ld.so.conf.d/20-amdgpu.conf 
/opt/amdgpu/lib/x86_64-linux-gnu
/opt/amdgpu/lib/i386-linux-gnu
```

下記環境で、docker上でのvceencc利用で動作可能となることを確認しました。

Ubuntu 20.04 + R9 5950X + Radeon RX460 + VCEEncC.elf 7.04


## 動機とコンテキスト
docker内でvceenccが実行できるよう変更したい。

