### PR TITLE
Update: [Server] VCEEncC を 7.07 に更新し、 1080p-60fps サポートを追加

### DIFF
--- a/.github/workflows/build_thirdparty.yaml
+++ b/.github/workflows/build_thirdparty.yaml
@@ -88,8 +88,8 @@ jobs:
           curl -L -o thirdparty/NVEncC/License.txt https://raw.githubusercontent.com/rigaya/NVEnc/master/NVEnc_license.txt
 
           # VCEEncC のアーカイブのダウンロード
-          curl -LO https://github.com/rigaya/VCEEnc/releases/download/7.05/VCEEncC_7.05_x64.7z
-          7z x -y -o"thirdparty/VCEEncC" VCEEncC_7.05_x64.7z
+          curl -LO https://github.com/rigaya/VCEEnc/releases/download/7.07/VCEEncC_7.07_x64.7z
+          7z x -y -o"thirdparty/VCEEncC" VCEEncC_7.07_x64.7z
           rm thirdparty/VCEEncC/hdr10plus_gen.exe
           mv thirdparty/VCEEncC/VCEEncC64.exe thirdparty/VCEEncC/VCEEncC.exe
           curl -L -o thirdparty/VCEEncC/License.txt https://raw.githubusercontent.com/rigaya/VCEEnc/master/VCEEnc_license.txt
@@ -234,8 +234,8 @@ jobs:
           curl -L -o thirdparty/NVEncC/License.txt https://raw.githubusercontent.com/rigaya/NVEnc/master/NVEnc_license.txt
 
           # VCEEncC のアーカイブのダウンロード
-          curl -LO https://github.com/rigaya/VCEEnc/releases/download/7.05/vceencc_7.05_Ubuntu20.04_amd64.deb
-          7z x -y vceencc_7.05_Ubuntu20.04_amd64.deb && tar xvf data.tar
+          curl -LO https://github.com/rigaya/VCEEnc/releases/download/7.07/vceencc_7.07_Ubuntu20.04_amd64.deb
+          7z x -y vceencc_7.07_Ubuntu20.04_amd64.deb && tar xvf data.tar
           mkdir thirdparty/VCEEncC/
           cp usr/bin/vceencc thirdparty/VCEEncC/VCEEncC.elf
           chmod a+x thirdparty/VCEEncC/VCEEncC.elf

--- a/server/app/tasks/LiveEncodingTask.py
+++ b/server/app/tasks/LiveEncodingTask.py
@@ -224,8 +224,12 @@ class LiveEncodingTask():
                 # インターレース解除 (60i → 30p (30fps))
                 options.append('--vpp-deinterlace normal --avsync forcecfr --gop-len 60')
         elif encoder_type == 'VCEEncC':
-            # VCEEncC では --vpp-deinterlace が使えないため、60i → 60p (60fps) へのインターレース解除ができない
-            options.append('--vpp-afs preset=default --avsync forcecfr --gop-len 60')
+            if quality == '1080p-60fps':
+                # インターレース解除 (60i → 60p (60fps))
+                options.append('--vpp-yadif mode=bob --avsync cfr --gop-len 120')
+            else:
+                # インターレース解除 (60i → 30p (30fps))
+                options.append('--vpp-afs preset=default --avsync forcecfr --gop-len 60')
         ## プリセット
         if encoder_type == 'QSVEncC':
             options.append('--quality balanced')


### PR DESCRIPTION
## 変更の種類
<!-- このプルリクエストではどのような変更が行われますか？ 該当するすべてのボックスに「x」を入力してください。 -->
- [ ] 不具合の修正
- [x] 新しい機能の追加
- [ ] 改善・リファクタリング（機能は追加されないが、動作やコードを改善する破壊的でない変更）

## チェックリスト:
<!-- 以下のすべての点に目を通し、該当するすべてのボックスに「x」を入力してください。 -->
- [x] [開発資料](https://mango-garlic-eff.notion.site/KonomiTV-90f4b25555c14b9ba0cf5498e6feb1c3) と [データベース設計](https://mango-garlic-eff.notion.site/KonomiTV-544e02334c89420fa24804ec70f46b6d) は読みましたか？
  - もともと自分用のメモですが、このプロジェクトの開発方針や設計などが記載されています。開発時の参考にしてください。
- [x] Git のコミットメッセージは開発資料に記載のフォーマットになっていますか？（重要）
  - このプロジェクト上のコミットメッセージは、基本的に全てこのフォーマットに従って記述されています（文字数は問いません）。
  - 正しいフォーマットになっていない場合、force push で必ずコミットメッセージを変更してから送信してください。
- [x] このプロジェクトのコーディング規約に従ったコードになっていますか？
  - コーディング規約は開発資料に記載されています。
  - そもそもコーディング規約と言えるほど大層なものではありませんが、一度目を通しておいてください。
- [x] プルリクエストは master ブランチに送信されていますか？
  - release ブランチはリリースした時にしか更新されません。必ず master ブランチに送信してください。

## 説明
VCEEncC 7.06 で追加した --vpp-yadif の 60fps 化機能を使用して、VCEEncC でも 1080p-60fps で動作可能なよう変更します。

下記のように現実的な GPU 使用率で動作可能なことを確認しました。

環境: Win11 + R9 5950X + Radeon RX460

![vceencc_1080p_60fps](https://user-images.githubusercontent.com/815947/186435689-5bed331a-935e-407f-95a1-4e7f05a1445b.png)

## 動機とコンテキスト
VCEEncC のみ、60fps モードに非対応な状況を改善したいと考えております。

