### PR TITLE
Add: [Server][EDCB] コマンドを追加

### DIFF
--- a/server/app/utils/EDCB.py
+++ b/server/app/utils/EDCB.py
@@ -704,20 +704,13 @@ class CtrlCmdUtil:
 
     async def sendViewSetBonDriver(self, name: str) -> bool:
         """ BonDriver の切り替え """
-        buf = bytearray()
-        self.__writeInt(buf, self.__CMD_VIEW_APP_SET_BONDRIVER)
-        self.__writeInt(buf, 0)
-        self.__writeString(buf, name)
-        self.__writeIntInplace(buf, 4, len(buf) - 8)
-        ret, _ = await self.__sendAndReceive(buf)
+        ret, _ = await self.__sendCmd(self.__CMD_VIEW_APP_SET_BONDRIVER,
+                                      lambda buf: self.__writeString(buf, name))
         return ret == self.__CMD_SUCCESS
 
     async def sendViewGetBonDriver(self) -> str | None:
         """ 使用中の BonDriver のファイル名を取得 """
-        buf = bytearray()
-        self.__writeInt(buf, self.__CMD_VIEW_APP_GET_BONDRIVER)
-        self.__writeInt(buf, 0)
-        ret, rbuf = await self.__sendAndReceive(buf)
+        ret, rbuf = await self.__sendCmd(self.__CMD_VIEW_APP_GET_BONDRIVER)
         if ret == self.__CMD_SUCCESS:
             try:
                 return self.__readString(memoryview(rbuf), [0], len(rbuf))
@@ -727,28 +720,18 @@ class CtrlCmdUtil:
 
     async def sendViewSetCh(self, set_ch_info: SetChInfo) -> bool:
         """ チャンネル切り替え """
-        buf = bytearray()
-        self.__writeInt(buf, self.__CMD_VIEW_APP_SET_CH)
-        self.__writeInt(buf, 0)
-        self.__writeSetChInfo(buf, set_ch_info)
-        self.__writeIntInplace(buf, 4, len(buf) - 8)
-        ret, _ = await self.__sendAndReceive(buf)
+        ret, _ = await self.__sendCmd(self.__CMD_VIEW_APP_SET_CH,
+                                      lambda buf: self.__writeSetChInfo(buf, set_ch_info))
         return ret == self.__CMD_SUCCESS
 
     async def sendViewAppClose(self) -> bool:
         """ アプリケーションの終了 """
-        buf = bytearray()
-        self.__writeInt(buf, self.__CMD_VIEW_APP_CLOSE)
-        self.__writeInt(buf, 0)
-        ret, _ = await self.__sendAndReceive(buf)
+        ret, _ = await self.__sendCmd(self.__CMD_VIEW_APP_CLOSE)
         return ret == self.__CMD_SUCCESS
 
     async def sendEnumService(self) -> list[ServiceInfo] | None:
         """ サービス一覧を取得する """
-        buf = bytearray()
-        self.__writeInt(buf, self.__CMD_EPG_SRV_ENUM_SERVICE)
-        self.__writeInt(buf, 0)
-        ret, rbuf = await self.__sendAndReceive(buf)
+        ret, rbuf = await self.__sendCmd(self.__CMD_EPG_SRV_ENUM_SERVICE)
         if ret == self.__CMD_SUCCESS:
             try:
                 return self.__readVector(self.__readServiceInfo, memoryview(rbuf), [0], len(rbuf))
@@ -758,12 +741,8 @@ class CtrlCmdUtil:
 
     async def sendEnumPgInfoEx(self, service_time_list: list[int]) -> list[ServiceEventInfo] | None:
         """ サービス指定と時間指定で番組情報一覧を取得する """
-        buf = bytearray()
-        self.__writeInt(buf, self.__CMD_EPG_SRV_ENUM_PG_INFO_EX)
-        self.__writeInt(buf, 0)
-        self.__writeVector(self.__writeLong, buf, service_time_list)
-        self.__writeIntInplace(buf, 4, len(buf) - 8)
-        ret, rbuf = await self.__sendAndReceive(buf)
+        ret, rbuf = await self.__sendCmd(self.__CMD_EPG_SRV_ENUM_PG_INFO_EX,
+                                         lambda buf: self.__writeVector(self.__writeLong, buf, service_time_list))
         if ret == self.__CMD_SUCCESS:
             try:
                 return self.__readVector(self.__readServiceEventInfo, memoryview(rbuf), [0], len(rbuf))
@@ -773,12 +752,8 @@ class CtrlCmdUtil:
 
     async def sendEnumPgArc(self, service_time_list: list[int]) -> list[ServiceEventInfo] | None:
         """ サービス指定と時間指定で過去番組情報一覧を取得する """
-        buf = bytearray()
-        self.__writeInt(buf, self.__CMD_EPG_SRV_ENUM_PG_ARC)
-        self.__writeInt(buf, 0)
-        self.__writeVector(self.__writeLong, buf, service_time_list)
-        self.__writeIntInplace(buf, 4, len(buf) - 8)
-        ret, rbuf = await self.__sendAndReceive(buf)
+        ret, rbuf = await self.__sendCmd(self.__CMD_EPG_SRV_ENUM_PG_ARC,
+                                         lambda buf: self.__writeVector(self.__writeLong, buf, service_time_list))
         if ret == self.__CMD_SUCCESS:
             try:
                 return self.__readVector(self.__readServiceEventInfo, memoryview(rbuf), [0], len(rbuf))
@@ -788,25 +763,16 @@ class CtrlCmdUtil:
 
     async def sendFileCopy(self, name: str) -> bytes | None:
         """ 指定ファイルを転送する """
-        buf = bytearray()
-        self.__writeInt(buf, self.__CMD_EPG_SRV_FILE_COPY)
-        self.__writeInt(buf, 0)
-        self.__writeString(buf, name)
-        self.__writeIntInplace(buf, 4, len(buf) - 8)
-        ret, rbuf = await self.__sendAndReceive(buf)
+        ret, rbuf = await self.__sendCmd(self.__CMD_EPG_SRV_FILE_COPY,
+                                         lambda buf: self.__writeString(buf, name))
         if ret == self.__CMD_SUCCESS:
             return rbuf
         return None
 
     async def sendFileCopy2(self, name_list: list[str]) -> list[FileData] | None:
         """ 指定ファイルをまとめて転送する """
-        buf = bytearray()
-        self.__writeInt(buf, self.__CMD_EPG_SRV_FILE_COPY2)
-        self.__writeInt(buf, 0)
-        self.__writeUshort(buf, self.__CMD_VER)
-        self.__writeVector(self.__writeString, buf, name_list)
-        self.__writeIntInplace(buf, 4, len(buf) - 8)
-        ret, rbuf = await self.__sendAndReceive(buf)
+        ret, rbuf = await self.__sendCmd2(self.__CMD_EPG_SRV_FILE_COPY2,
+                                          lambda buf: self.__writeVector(self.__writeString, buf, name_list))
         if ret == self.__CMD_SUCCESS:
             bufview = memoryview(rbuf)
             pos = [0]
@@ -819,12 +785,8 @@ class CtrlCmdUtil:
 
     async def sendNwTVIDSetCh(self, set_ch_info: SetChInfo) -> int | None:
         """ NetworkTV モードの View アプリのチャンネルを切り替え、または起動の確認 (ID 指定) """
-        buf = bytearray()
-        self.__writeInt(buf, self.__CMD_EPG_SRV_NWTV_ID_SET_CH)
-        self.__writeInt(buf, 0)
-        self.__writeSetChInfo(buf, set_ch_info)
-        self.__writeIntInplace(buf, 4, len(buf) - 8)
-        ret, rbuf = await self.__sendAndReceive(buf)
+        ret, rbuf = await self.__sendCmd(self.__CMD_EPG_SRV_NWTV_ID_SET_CH,
+                                         lambda buf: self.__writeSetChInfo(buf, set_ch_info))
         if ret == self.__CMD_SUCCESS:
             try:
                 return self.__readInt(memoryview(rbuf), [0], len(rbuf))
@@ -834,22 +796,13 @@ class CtrlCmdUtil:
 
     async def sendNwTVIDClose(self, nwtv_id: int) -> bool:
         """ NetworkTV モードで起動中の View アプリを終了 (ID 指定) """
-        buf = bytearray()
-        self.__writeInt(buf, self.__CMD_EPG_SRV_NWTV_ID_CLOSE)
-        self.__writeInt(buf, 0)
-        self.__writeInt(buf, nwtv_id)
-        self.__writeIntInplace(buf, 4, len(buf) - 8)
-        ret, _ = await self.__sendAndReceive(buf)
+        ret, _ = await self.__sendCmd(self.__CMD_EPG_SRV_NWTV_ID_CLOSE,
+                                      lambda buf: self.__writeInt(buf, nwtv_id))
         return ret == self.__CMD_SUCCESS
 
     async def sendEnumRecInfoBasic(self) -> list[RecFileInfo] | None:
         """ 録画済み情報一覧取得 (programInfo と errInfo を除く) """
-        buf = bytearray()
-        self.__writeInt(buf, self.__CMD_EPG_SRV_ENUM_RECINFO_BASIC2)
-        self.__writeInt(buf, 0)
-        self.__writeUshort(buf, self.__CMD_VER)
-        self.__writeIntInplace(buf, 4, len(buf) - 8)
-        ret, rbuf = await self.__sendAndReceive(buf)
+        ret, rbuf = await self.__sendCmd2(self.__CMD_EPG_SRV_ENUM_RECINFO_BASIC2)
         if ret == self.__CMD_SUCCESS:
             bufview = memoryview(rbuf)
             pos = [0]
@@ -862,13 +815,8 @@ class CtrlCmdUtil:
 
     async def sendGetRecInfo(self, info_id: int) -> RecFileInfo | None:
         """ 録画済み情報取得 """
-        buf = bytearray()
-        self.__writeInt(buf, self.__CMD_EPG_SRV_GET_RECINFO2)
-        self.__writeInt(buf, 0)
-        self.__writeUshort(buf, self.__CMD_VER)
-        self.__writeInt(buf, info_id)
-        self.__writeIntInplace(buf, 4, len(buf) - 8)
-        ret, rbuf = await self.__sendAndReceive(buf)
+        ret, rbuf = await self.__sendCmd2(self.__CMD_EPG_SRV_GET_RECINFO2,
+                                          lambda buf: self.__writeInt(buf, info_id))
         if ret == self.__CMD_SUCCESS:
             bufview = memoryview(rbuf)
             pos = [0]
@@ -997,6 +945,25 @@ class CtrlCmdUtil:
         if len(rbuf) == size:
             return ret, rbuf
         return None, b''
+
+    async def __sendCmd(self, cmd: int, write_func: Callable[[bytearray], None] | None = None) -> tuple[int | None, bytes]:
+        buf = bytearray()
+        self.__writeInt(buf, cmd)
+        self.__writeInt(buf, 0)
+        if write_func:
+            write_func(buf)
+        self.__writeIntInplace(buf, 4, len(buf) - 8)
+        return await self.__sendAndReceive(buf)
+
+    async def __sendCmd2(self, cmd2: int, write_func: Callable[[bytearray], None] | None = None) -> tuple[int | None, bytes]:
+        buf = bytearray()
+        self.__writeInt(buf, cmd2)
+        self.__writeInt(buf, 0)
+        self.__writeUshort(buf, self.__CMD_VER)
+        if write_func:
+            write_func(buf)
+        self.__writeIntInplace(buf, 4, len(buf) - 8)
+        return await self.__sendAndReceive(buf)
 
     @staticmethod
     def __writeByte(buf: bytearray, v: int) -> None:

--- a/server/app/utils/EDCB.py
+++ b/server/app/utils/EDCB.py
@@ -560,7 +560,7 @@ class RecFileInfo(TypedDict, total=False):
     comment: str
     program_info: str
     err_info: str
-    protect_flag: int
+    protect_flag: bool
 
 
 class ShortEventInfo(TypedDict):
@@ -842,7 +842,7 @@ class CtrlCmdUtil:
         ret, _ = await self.__sendAndReceive(buf)
         return ret == self.__CMD_SUCCESS
 
-    async def sendEnumRecInfoBasic2(self) -> list[RecFileInfo] | None:
+    async def sendEnumRecInfoBasic(self) -> list[RecFileInfo] | None:
         """ 録画済み情報一覧取得 (programInfo と errInfo を除く) """
         buf = bytearray()
         self.__writeInt(buf, self.__CMD_EPG_SRV_ENUM_RECINFO_BASIC2)
@@ -860,7 +860,7 @@ class CtrlCmdUtil:
                 pass
         return None
 
-    async def sendGetRecInfo2(self, info_id: int) -> RecFileInfo | None:
+    async def sendGetRecInfo(self, info_id: int) -> RecFileInfo | None:
         """ 録画済み情報取得 """
         buf = bytearray()
         self.__writeInt(buf, self.__CMD_EPG_SRV_GET_RECINFO2)
@@ -1169,7 +1169,7 @@ class CtrlCmdUtil:
             'comment': cls.__readString(buf, pos, size),
             'program_info': cls.__readString(buf, pos, size),
             'err_info': cls.__readString(buf, pos, size),
-            'protect_flag': cls.__readByte(buf, pos, size)
+            'protect_flag': cls.__readByte(buf, pos, size) != 0
         }
         pos[0] = size
         return v


### PR DESCRIPTION
## 変更の種類
<!-- このプルリクエストではどのような変更が行われますか？ 該当するすべてのボックスに「x」を入力してください。 -->
- [ ] 不具合の修正
- [ ] 新しい機能の追加
- [x] 改善・リファクタリング（機能は追加されないが、動作やコードを改善する破壊的でない変更）

## チェックリスト:
<!-- 以下のすべての点に目を通し、該当するすべてのボックスに「x」を入力してください。 -->
- [x] [開発資料](https://mango-garlic-eff.notion.site/KonomiTV-90f4b25555c14b9ba0cf5498e6feb1c3) と [データベース設計](https://mango-garlic-eff.notion.site/KonomiTV-544e02334c89420fa24804ec70f46b6d) は読みましたか？
  - もともと自分用のメモですが、このプロジェクトの開発方針や設計などが記載されています。開発時の参考にしてください。
- [x] Git のコミットメッセージは開発資料に記載のフォーマットになっていますか？（重要）
  - このプロジェクト上のコミットメッセージは、基本的に全てこのフォーマットに従って記述されています（文字数は問いません）。
  - 正しいフォーマットになっていない場合、force push で必ずコミットメッセージを変更してから送信してください。
- [x] このプロジェクトのコーディング規約に従ったコードになっていますか？
  - コーディング規約は開発資料に記載されています。
  - そもそもコーディング規約と言えるほど大層なものではありませんが、一度目を通しておいてください。
- [x] プルリクエストは master ブランチに送信されていますか？
  - release ブランチはリリースした時にしか更新されません。必ず master ブランチに送信してください。

## 説明
EDCB バックエンドの制御コマンドの追加を行いました。Python 型ヒントの詳細化も併せて行いました。
e790c702c3a37af6bcf048be467e1889e836c532 は空白類の PEP8 規約への調整と、 asyncio のキャンセル時の整合性のため `Exception` 例外のみキャッチするように変更するものです。
32a8b9b44fa4021cbb0d025fd8dd10dfa5bb61fe は表題通りで、外部的な仕様変更はないですが利用側の型ヒントの調整が必要になるかもしれません。
a1abf6255965543faa11701fc9e118adeb252f8e の更新通知については、一例ですが以下のように利用することを想定しています。

```python
edcb = CtrlCmdUtil()
# TCP/IP モードでは EpgTimerSrv の「無通信タイムアウト」間隔でロングポーリングになる
# 既定のタイムアウトだと早めに切断してしまいもったいないので長めにする
#edcb.setConnectTimeOutSec(180)
target_count = 0
check_restart_time = time.monotonic()
while True:
    t = time.monotonic()
    info = await edcb.sendGetNotifySrvInfo(target_count)
    if info:
        # 新しい通知がきた (ここで通知に従って各情報一覧を取得しなおす)
        target_count = info['count']
        check_restart_time = time.monotonic()
    elif time.monotonic() - t < 5:
        # パイプモードは単なるポーリングなのでここを踏む
        # TCP/IP モードでは通常ここは踏まない。ただしエラー時ビジーループになるのを回避できるので推奨
        await asyncio.sleep(5)

    # EpgTimerSrv の中途終了や再起動を想定しないなら以下は不要
    # EpgTimerSrv が再起動してカウントが戻った場合に通知がこなくなるのを回避する
    t = time.monotonic()
    if t - check_restart_time > 30:
        check_restart_time = t
        info = await edcb.sendGetNotifySrvStatus()
        if info and info['count'] < target_count:
            # たぶん再起動した (ここで情報一覧をすべて取得しなおす)
            # 通知を維持するのが目的なので再起動を必ず検出できるわけではない
            target_count = info['count']
```

## 動機とコンテキスト
EDCB バックエンドの制御コマンドの拡張を希望されていたので、今後必要になりそうとこちらが考えたコマンドについてひととおり追加するもです。
