### PR TITLE
Update: [Server] ネットワークID分岐「CATV」を独自ネットワークIDでしている4Kチャンネルも含むように修正

### DIFF
--- a/server/app/utils/TSInformation.py
+++ b/server/app/utils/TSInformation.py
@@ -242,7 +242,8 @@ class TSInformation:
         # デジタル放送高度リマックス: 0xFFFA (ケーブル4Kチャンネル (H.264, H.265))
         # JC-HITSトランスモジュレーション: 0xFFFD (HD・SD チャンネル (MPEG-2))
         # 高度JC-HITSトランスモジュレーション: 0xFFF9 (ケーブル4Kチャンネル (H.264, H.265))
-        if network_id == 0xFFFE or network_id == 0xFFFA or network_id == 0xFFFD or network_id == 0xFFF9:
+        # ケーブルテレビの独自4Kチャンネル: 0xFFF7 (一部ケーブルテレビ事業者)
+        if network_id == 0xFFFE or network_id == 0xFFFA or network_id == 0xFFFD or network_id == 0xFFF9 or network_id == 0xFFF7:
             return 'CATV'
 
         # 124/128度CSデジタル放送


### PR DESCRIPTION
## 変更の種類
<!-- このプルリクエストではどのような変更が行われますか？ 該当するすべてのボックスに「x」を入力してください。 -->
- [ x ] 不具合の修正
- [ ] 新しい機能の追加
- [ ] 改善・リファクタリング（機能は追加されないが、動作やコードを改善する破壊的でない変更）

## チェックリスト:
<!-- 以下のすべての点に目を通し、該当するすべてのボックスに「x」を入力してください。 -->
- [ x ] [開発資料](https://mango-garlic-eff.notion.site/KonomiTV-90f4b25555c14b9ba0cf5498e6feb1c3) と [データベース設計](https://mango-garlic-eff.notion.site/KonomiTV-544e02334c89420fa24804ec70f46b6d) は読みましたか？
  - もともと自分用のメモですが、このプロジェクトの開発方針や設計などが記載されています。開発時の参考にしてください。
- [ x ] Git のコミットメッセージは開発資料に記載のフォーマットになっていますか？（重要）
  - このプロジェクト上のコミットメッセージは、基本的に全てこのフォーマットに従って記述されています（文字数は問いません）。
  - 正しいフォーマットになっていない場合、force push で必ずコミットメッセージを変更してから送信してください。
- [ x ] このプロジェクトのコーディング規約に従ったコードになっていますか？
  - コーディング規約は開発資料に記載されています。
  - そもそもコーディング規約と言えるほど大層なものではありませんが、一度目を通しておいてください。
- [ x ] プルリクエストは master ブランチに送信されていますか？
  - release ブランチはリリースした時にしか更新されません。必ず master ブランチに送信してください。

## 説明
ネットワークIDの判定分岐でCATVで判定にするネットワークIDの修正


## 動機とコンテキスト
「ARIB STD-B10 第2部 付録N」に区分されてないネットワークIDで、4K放送しているチャンネルのネットワークIDをタブ分類「CATV」に入るように修正を行った。

(経緯の始まり)
https://x.com/TVRemotePlus/status/1791152164901093469
