### PR TITLE
Windows環境におけるNVEncCのプロセス初期化高速化

### DIFF
--- a/server/app/streams/LiveEncodingTask.py
+++ b/server/app/streams/LiveEncodingTask.py
@@ -298,9 +298,9 @@ class LiveEncodingTask:
         ## QSVEncC と rkmppenc では OpenCL を使用しないので、無効化することで初期化フェーズを高速化する
         if encoder_type == 'QSVEncC' or encoder_type == 'rkmppenc':
             options.append('--disable-opencl')
-        ## NVEncC では NVML によるモニタリングを無効化することで初期化フェーズを高速化する
+        ## NVEncC では NVML によるモニタリングと DX11 を無効化することで初期化フェーズを高速化する
         if encoder_type == 'NVEncC':
-            options.append('--disable-nvml 1')
+            options.append('--disable-nvml 1 --disable-dx11')
 
         # 映像
         ## コーデック


### PR DESCRIPTION
## 変更の種類
<!-- このプルリクエストではどのような変更が行われますか？ 該当するすべてのボックスに「x」を入力してください。 -->
- [ ] 不具合の修正
- [ ] 新しい機能の追加
- [x] 改善・リファクタリング（機能は追加されないが、動作やコードを改善する破壊的でない変更）

## チェックリスト:
<!-- 以下のすべての点に目を通し、該当するすべてのボックスに「x」を入力してください。 -->
- [x] [開発資料](https://mango-garlic-eff.notion.site/KonomiTV-90f4b25555c14b9ba0cf5498e6feb1c3) と [データベース設計](https://mango-garlic-eff.notion.site/KonomiTV-544e02334c89420fa24804ec70f46b6d) は読みましたか？
  - もともと自分用のメモですが、このプロジェクトの開発方針や設計などが記載されています。開発時の参考にしてください。
- [x] Git のコミットメッセージは開発資料に記載のフォーマットになっていますか？（重要）
  - このプロジェクト上のコミットメッセージは、基本的に全てこのフォーマットに従って記述されています（文字数は問いません）。
  - 正しいフォーマットになっていない場合、force push で必ずコミットメッセージを変更してから送信してください。
- [x] このプロジェクトのコーディング規約に従ったコードになっていますか？
  - コーディング規約は開発資料に記載されています。
  - そもそもコーディング規約と言えるほど大層なものではありませんが、一度目を通しておいてください。
- [x] プルリクエストは master ブランチに送信されていますか？
  - release ブランチはリリースした時にしか更新されません。必ず master ブランチに送信してください。

## 説明
NVEnc 7.70で追加した ```--disable-dx11``` を追加し、NVEnc 7.55以前と同様の初期化速度を実現します。

## 動機とコンテキスト
NVEncでは7.56からNGXライブラリへの対応のため、Windows環境においてDirectX11(以下DX11)のよるデバイス初期化を追加しました。しかし、この初期化処理がそこそこ時間がかかってしまいます。

現在、NVEncでDX11を必要とするのは、NGXライブラリとlibplaceboライブラリを使用するときです。KonomiTVではいずれも必要ないため、NVEnc 7.70ではDX11初期化をスキップするオプション(```--disable-dx11```)を追加しました。

これにより、初期化時間を120ms前後削減し、NVIDIA GPUが1枚の環境では従来の280～300ms前後に戻すことができます(@ Win11 + i9 12900K + RTX4080)。(Windowsで初期化処理の遅いQSVEncと異なり、NVEncの初期化処理はWindowsでも高速です)

なお、Linux環境においても```--disable-dx11```を付与して問題ありません(もともとDX11初期化を行わないので単に無視されます)。
