### PR TITLE
Fix: [Dockerfile] ENTRYPOINT を配列形式に変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,4 +102,4 @@ COPY --from=client-builder /code/client/dist/ /code/client/dist/
 COPY ./config.example.yaml /code/config.example.yaml
 
 # KonomiTV サーバーを起動
-ENTRYPOINT /code/server/.venv/bin/python KonomiTV.py
+ENTRYPOINT ["/code/server/.venv/bin/python", "KonomiTV.py"]


### PR DESCRIPTION
## 変更の種類
<!-- このプルリクエストではどのような変更が行われますか？ 該当するすべてのボックスに「x」を入力してください。 -->
- [x] 不具合の修正
- [ ] 新しい機能の追加
- [ ] 改善・リファクタリング（機能は追加されないが、動作やコードを改善する破壊的でない変更）

## チェックリスト:
<!-- 以下のすべての点に目を通し、該当するすべてのボックスに「x」を入力してください。 -->
- [x] [開発資料](https://mango-garlic-eff.notion.site/KonomiTV-90f4b25555c14b9ba0cf5498e6feb1c3) と [データベース設計](https://mango-garlic-eff.notion.site/KonomiTV-544e02334c89420fa24804ec70f46b6d) は読みましたか？
  - もともと自分用のメモですが、このプロジェクトの開発方針や設計などが記載されています。開発時の参考にしてください。
- [x] Git のコミットメッセージは開発資料に記載のフォーマットになっていますか？（重要）
  - このプロジェクト上のコミットメッセージは、基本的に全てこのフォーマットに従って記述されています（文字数は問いません）。
  - 正しいフォーマットになっていない場合、force push で必ずコミットメッセージを変更してから送信してください。
- [x] このプロジェクトのコーディング規約に従ったコードになっていますか？
  - コーディング規約は開発資料に記載されています。
  - そもそもコーディング規約と言えるほど大層なものではありませんが、一度目を通しておいてください。
- [x] プルリクエストは master ブランチに送信されていますか？
  - release ブランチはリリースした時にしか更新されません。必ず master ブランチに送信してください。

## 説明
<!-- このプルリクエストでの変更点を詳しく説明してください。 -->
ENTRYPOINTの定義を配列形式に変更しました。
（JSON配列で記載する必要があり`'`だと動作しないため、ファイル内で混在する状態になっています）

これにより、コンテナ環境下においてKonomiTV (`/code/server/.venv/bin/python /code/server/.venv/bin/python KonomiTV.py`)はコンテナ終了時の終了信号を受け取れるようになります。

結果として、コンテナ環境下においても終了処理が正しく実行されるようになります。

## 動機とコンテキスト
<!-- この変更はなぜ必要ですか？どのような問題が解決されますか？ -->
<!-- この変更で未解決の Issue が修正される場合は、ここにリンクを貼ってください。 -->
Dockerを用いて運用する際、コンテナの終了時は毎回強制終了(10秒経過してSIGKILL)しており、`server/app/app.py`で定義されている終了処理が行われていませんでした。
これは、`/code/server/.venv/bin/python KonomiTV.py`がシェル経由で実行されており、アプリケーションが本来受け取るべき終了信号(SIGTERM)を、`/bin/sh`が受け取ってしまうことと、それをアプリケーションまで伝播しないことが理由です。
<img width="1176" alt="image" src="https://github.com/user-attachments/assets/0f27b12c-b805-41a4-a97e-fe205226245b" />

今回の修正により、SIGTERMはアプリケーション（KonomiTVの場合Uvicorn）が受け取るようになり、`@app.on_event('shutdown')`で発火する終了処理が実行されるようになります。
<img width="1119" alt="image" src="https://github.com/user-attachments/assets/621f880d-8524-4c18-ad29-00869306889a" />

`tini`や`dumb-init`のような終了信号を転送してくれる軽量initプロセスも存在しますが、コンテナ内でどうしてもシェル起動したいという動機はないように思えたため、今回は選択していません。

## 動作確認

### Before

10秒が経過し、強制終了がかかっている

<img width="796" alt="image" src="https://github.com/user-attachments/assets/4b28f2cc-8eb7-45b1-897a-deb7defb31cf" />

動作確認のために追加したログは表示されておらず、アプリケーションが終了した旨のログも出ていない
<img width="1580" alt="image" src="https://github.com/user-attachments/assets/5c2941c4-a1cb-4111-9598-3e137d35218c" />

### After

タイムアウト時間以内( 1.5秒 )で終了するようになっている

<img width="811" alt="image" src="https://github.com/user-attachments/assets/1bdb21ba-f65e-4240-abf0-f059c2fcf5aa" />

動作確認のために追加したログが表示されており、終了処理に入っていることを確認しています。
<img width="1737" alt="image" src="https://github.com/user-attachments/assets/f6803ba8-3faa-435a-9fae-67444af71648" />
