### PR TITLE
Refactor: [Client][Watch/Header/clock] 時間表示方法を改善

### DIFF
--- a/client/src/components/Watch/Header.vue
+++ b/client/src/components/Watch/Header.vue
@@ -40,24 +40,33 @@ export default defineComponent({
             ProgramUtils: Object.freeze(ProgramUtils),
 
             // 現在時刻
-            time: dayjs().format(Utils.isSmartphoneHorizontal() ? 'HH:mm:ss' : 'YYYY/MM/DD HH:mm:ss'),
+            time: '',
 
-            // 現在時刻更新用のインターバルの ID
-            time_interval_id: 0,
         };
     },
     computed: {
         ...mapStores(useChannelsStore, usePlayerStore),
     },
+    methods: {
+        updateTimeCore() {
+            const time = dayjs();
+            this.time = time.format(Utils.isSmartphoneHorizontal() ? 'HH:mm:ss' : 'YYYY/MM/DD HH:mm:ss');
+            const ms = time.millisecond();
+            return ms > 800 ? 500 : 1000 - ms;
+        },
+        uptimeTime() {
+            setTimeout(() => {
+                this.uptimeTime();
+            }, this.updateTimeCore());
+        },
+    },
     created() {
-        // 現在時刻を 0.1 秒おきに更新
-        this.time_interval_id = window.setInterval(() => {
-            this.time = dayjs().format(Utils.isSmartphoneHorizontal() ? 'HH:mm:ss' : 'YYYY/MM/DD HH:mm:ss');
-        }, 0.1 * 1000);
+        setTimeout(() => {
+            this.uptimeTime();
+        }, 1000);
     },
     beforeUnmount() {
-        // インターバルをクリア
-        window.clearInterval(this.time_interval_id);
+        this.uptimeTime = ()=>{ };
     },
 });
 


### PR DESCRIPTION
## 変更の種類
<!-- このプルリクエストではどのような変更が行われますか？ 該当するすべてのボックスに「x」を入力してください。 -->
- [ ] 不具合の修正
- [ ] 新しい機能の追加
- [x] 改善・リファクタリング（機能は追加されないが、動作やコードを改善する破壊的でない変更）

## チェックリスト:
<!-- 以下のすべての点に目を通し、該当するすべてのボックスに「x」を入力してください。 -->
- [x] [開発資料](https://mango-garlic-eff.notion.site/KonomiTV-90f4b25555c14b9ba0cf5498e6feb1c3) と [データベース設計](https://mango-garlic-eff.notion.site/KonomiTV-544e02334c89420fa24804ec70f46b6d) は読みましたか？
  - もともと自分用のメモですが、このプロジェクトの開発方針や設計などが記載されています。開発時の参考にしてください。
- [x] Git のコミットメッセージは開発資料に記載のフォーマットになっていますか？（重要）
  - このプロジェクト上のコミットメッセージは、基本的に全てこのフォーマットに従って記述されています（文字数は問いません）。
  - 正しいフォーマットになっていない場合、force push で必ずコミットメッセージを変更してから送信してください。
- [x] このプロジェクトのコーディング規約に従ったコードになっていますか？
  - コーディング規約は開発資料に記載されています。
  - そもそもコーディング規約と言えるほど大層なものではありませんが、一度目を通しておいてください。
- [x] プルリクエストは master ブランチに送信されていますか？
  - release ブランチはリリースした時にしか更新されません。必ず master ブランチに送信してください。

## 説明
Refactor: [Client][Watch/Header/clock] 時間表示方法を改善。

## 動機とコンテキスト
この変更は、setInterval を使用することによるパフォーマンス低下を防ぐために行いました。
0.1秒間隔での定期的な更新は無駄な処理を引き起こす可能性があり、スマートフォンやリソースが限られたデバイスでのパフォーマンスに影響を与えることがあります。
setTimeout を利用することで、無駄な処理を削減することができます。

---

私のMacでページが初期化される際 (`created()`)、ページのレンダリングと時間表示の更新が競合し、時間が跳ねる問題が発生することがありました。
そして一秒の`setTimeout`をさせることで、ページの描画が安定してから時間更新を開始できるようにしています。
多分将来 `requestAnimationFrame` を活用することで、さらにスムーズなパフォーマンスを実現しました。


：）