### PR TITLE
Mirakurun (BS4K fork) 環境下での BS4K 再生の改善

### DIFF
--- a/server/app/models/Program.py
+++ b/server/app/models/Program.py
@@ -374,8 +374,12 @@ class Program(TortoiseModel):
                     program.video_codec = None
                     program.video_resolution = None
                     if 'video' in program_info:
-                        program.video_type = ariblib.constants.COMPONENT_TYPE \
-                            [program_info['video']['streamContent']].get(program_info['video']['componentType'], 'Unknown')
+                        if (program_info['video']['streamContent'] is not None or
+                            program_info['video']['componentType'] is not None):
+                            program.video_type = ariblib.constants.COMPONENT_TYPE \
+                                [program_info['video']['streamContent']].get(program_info['video']['componentType'], 'Unknown')
+                        else:
+                            program.video_type = 'Unknown'
                         program.video_codec = program_info['video']['type']
                         program.video_resolution = program_info['video']['resolution']
 

--- a/server/app/streams/LiveEncodingTask.py
+++ b/server/app/streams/LiveEncodingTask.py
@@ -284,9 +284,12 @@ class LiveEncodingTask:
         # 入力
         ## --input-probesize, --input-analyze をつけることで、ストリームの分析時間を短縮できる
         ## 両方つけるのが重要で、--input-analyze だけだとエンコーダーがフリーズすることがある
-        ## BS4K では --fps を指定しない
-        input_fps = '' if channel_type == 'BS4K' else '--fps 30000/1001'
-        options.append(f'--input-format mpegts {input_fps} --input-probesize {input_probesize}K --input-analyze {input_analyze} --input -')
+        options.append(f'--input-format mpegts --input-probesize {input_probesize}K --input-analyze {input_analyze}')
+        ## BS4K 以外では 30fps を指定する
+        if channel_type != 'BS4K':
+            options.append('--fps 30000/1001')
+        ## 入力を指定する
+        options.append('--input -')
         ## VCEEncC の HW デコーダーはエラー耐性が低く TS を扱う用途では不安定なので、SW デコーダーを利用する
         if encoder_type == 'VCEEncC':
             options.append('--avsw')


### PR DESCRIPTION
## 変更の種類
<!-- このプルリクエストではどのような変更が行われますか？ 該当するすべてのボックスに「x」を入力してください。 -->
- [x] 不具合の修正
- [ ] 新しい機能の追加
- [x] 改善・リファクタリング（機能は追加されないが、動作やコードを改善する破壊的でない変更）

## チェックリスト:
<!-- 以下のすべての点に目を通し、該当するすべてのボックスに「x」を入力してください。 -->
- [x] [開発資料](https://mango-garlic-eff.notion.site/KonomiTV-90f4b25555c14b9ba0cf5498e6feb1c3) と [データベース設計](https://mango-garlic-eff.notion.site/KonomiTV-544e02334c89420fa24804ec70f46b6d) は読みましたか？
  - もともと自分用のメモですが、このプロジェクトの開発方針や設計などが記載されています。開発時の参考にしてください。
- [x] Git のコミットメッセージは開発資料に記載のフォーマットになっていますか？（重要）
  - このプロジェクト上のコミットメッセージは、基本的に全てこのフォーマットに従って記述されています（文字数は問いません）。
  - 正しいフォーマットになっていない場合、force push で必ずコミットメッセージを変更してから送信してください。
- [x] このプロジェクトのコーディング規約に従ったコードになっていますか？
  - コーディング規約は開発資料に記載されています。
  - そもそもコーディング規約と言えるほど大層なものではありませんが、一度目を通しておいてください。
- [x] プルリクエストは master ブランチに送信されていますか？
  - release ブランチはリリースした時にしか更新されません。必ず master ブランチに送信してください。

## 説明
<!-- このプルリクエストでの変更点を詳しく説明してください。 -->
Mirakurun (BS4K fork) 導入環境での BS4K 再生を改善するものです。

1. Mirakurun からのストリームは (4K, HD 問わず) デコード前/後を指定して取得できますが、デコード後のものを取得するようにしています。
2. BS4K の HW エンコードでは、 LiveEncodingTask 内で "input_fps" をクリア ('') していますが、これは QSVEncC を使用している環境では 「[QSVEncC] Error: Unknown option:」 でエラー終了してしまうため、明示的に 60fps を指定することで修正しています。 (NULL が入っている気がしますが追えていません)
3. Mirakurun (BS4K fork) で確認したのですが、 BS4K 番組情報の video type に NULL が入ることがあるようです。 Mirakurun (BS4K fork) 側で対応すべきものかもしれませんが、 KonomiTV の番組情報アップデートに失敗＆入らなくても影響はなさそうですので、 NULL は無視するようにしています。


## 動機とコンテキスト
<!-- この変更はなぜ必要ですか？どのような問題が解決されますか？ -->
<!-- この変更で未解決の Issue が修正される場合は、ここにリンクを貼ってください。 -->
4K も KonomiTV で見たい！ 人のために…。
