### PR TITLE
セグメント長短縮時の NVEncC での録画再生安定化

### DIFF
--- a/server/app/streams/VideoEncodingTask.py
+++ b/server/app/streams/VideoEncodingTask.py
@@ -223,9 +223,10 @@ class VideoEncodingTask:
 
         # フラグ
         ## 主に HWEncC の起動を高速化するための設定
-        ## max_interleave_delta: mux 時に影響するオプションで、増やしすぎると CM で詰まりがちになる
-        ## リトライなしの場合は 500K (0.5秒) に設定し、リトライ回数に応じて 100K (0.1秒) ずつ増やす
-        max_interleave_delta = round(500 + (self._retry_count * 100))
+        ## max_interleave_delta: mux 時に影響するオプションで、ライブ再生では増やしすぎると CM で詰まりがちになる
+        ## 録画再生では逆に大きめでないと映像/音声のずれが大きくなりセグメント分割時に問題が生じるため、
+        ## 5000K (5秒) に設定し、リトライ回数に応じて 500K (0.5秒) ずつ増やす
+        max_interleave_delta = round(5000 + (self._retry_count * 500))
         options.append('-m avioflags:direct -m fflags:nobuffer+flush_packets -m flush_packets:1 -m max_delay:0')
         options.append(f'-m max_interleave_delta:{max_interleave_delta}K')
         ## QSVEncC と rkmppenc では OpenCL を使用しないので、無効化することで初期化フェーズを高速化する


### PR DESCRIPTION
## 変更の種類
<!-- このプルリクエストではどのような変更が行われますか？ 該当するすべてのボックスに「x」を入力してください。 -->
- [x] 不具合の修正
- [ ] 新しい機能の追加
- [ ] 改善・リファクタリング（機能は追加されないが、動作やコードを改善する破壊的でない変更）

## チェックリスト:
<!-- 以下のすべての点に目を通し、該当するすべてのボックスに「x」を入力してください。 -->
- [x] [開発資料](https://mango-garlic-eff.notion.site/KonomiTV-90f4b25555c14b9ba0cf5498e6feb1c3) と [データベース設計](https://mango-garlic-eff.notion.site/KonomiTV-544e02334c89420fa24804ec70f46b6d) は読みましたか？
  - もともと自分用のメモですが、このプロジェクトの開発方針や設計などが記載されています。開発時の参考にしてください。
- [x] Git のコミットメッセージは開発資料に記載のフォーマットになっていますか？（重要）
  - このプロジェクト上のコミットメッセージは、基本的に全てこのフォーマットに従って記述されています（文字数は問いません）。
  - 正しいフォーマットになっていない場合、force push で必ずコミットメッセージを変更してから送信してください。
- [x] このプロジェクトのコーディング規約に従ったコードになっていますか？
  - コーディング規約は開発資料に記載されています。
  - そもそもコーディング規約と言えるほど大層なものではありませんが、一度目を通しておいてください。
- [x] プルリクエストは master ブランチに送信されていますか？
  - release ブランチはリリースした時にしか更新されません。必ず master ブランチに送信してください。

## 説明
NVEncC でセグメント長短縮時の録画再生が安定しない問題を修正します。なお、 NVEncC の更新は不要です。

## 動機とコンテキスト
NVEncC でセグメント長を短縮すると安定しない問題を、muxオプションの max_interleave_delta を大きく変更することにより修正します。

max_interleave_delta は libavformat での mux 時のバッファサイズで、ライブ再生時には小さめにすることで muxer で生じる遅延を削減していました。

しかし、録画再生時にはライブ再生時と比べ処理速度が増大することから、muxer のバッファに投入される映像と音声の時刻ずれが拡大しやすく、小さめのバッファサイズでは時刻ずれを受け止めきれないようです。その結果、セグメント分割時の映像と音声のずれが大きくなり、再生が不安定になっていたようでした。

手元では、今回の max_interleave_delta 拡大でセグメント長を 6 秒まで短縮しても安定して再生できるようになりましたが、一度ご確認いただけないでしょうか。