### PR TITLE
Linux 環境における NVEncC のプロセス初期化高速化と安定化

### DIFF
--- a/server/app/streams/LiveEncodingTask.py
+++ b/server/app/streams/LiveEncodingTask.py
@@ -314,9 +314,9 @@ class LiveEncodingTask:
         ## QSVEncC と rkmppenc では OpenCL を使用しないので、無効化することで初期化フェーズを高速化する
         if encoder_type == 'QSVEncC' or encoder_type == 'rkmppenc':
             options.append('--disable-opencl')
-        ## NVEncC では NVML によるモニタリングと DX11 を無効化することで初期化フェーズを高速化する
+        ## NVEncC では NVML によるモニタリングと DX11, Vulkan を無効化することで初期化フェーズを高速化する
         if encoder_type == 'NVEncC':
-            options.append('--disable-nvml 1 --disable-dx11')
+            options.append('--disable-nvml 1 --disable-dx11 --disable-vulkan')
 
         # 映像
         ## コーデック

--- a/server/app/streams/VideoEncodingTask.py
+++ b/server/app/streams/VideoEncodingTask.py
@@ -233,9 +233,9 @@ class VideoEncodingTask:
         ## QSVEncC と rkmppenc では OpenCL を使用しないので、無効化することで初期化フェーズを高速化する
         if encoder_type == 'QSVEncC' or encoder_type == 'rkmppenc':
             options.append('--disable-opencl')
-        ## NVEncC では NVML によるモニタリングと DX11 を無効化することで初期化フェーズを高速化する
+        ## NVEncC では NVML によるモニタリングと DX11, Vulkan を無効化することで初期化フェーズを高速化する
         if encoder_type == 'NVEncC':
-            options.append('--disable-nvml 1 --disable-dx11')
+            options.append('--disable-nvml 1 --disable-dx11 --disable-vulkan')
 
         # 映像
         ## コーデック


### PR DESCRIPTION
## 変更の種類
<!-- このプルリクエストではどのような変更が行われますか？ 該当するすべてのボックスに「x」を入力してください。 -->
- [ ] 不具合の修正
- [ ] 新しい機能の追加
- [x] 改善・リファクタリング（機能は追加されないが、動作やコードを改善する破壊的でない変更）

## チェックリスト:
<!-- 以下のすべての点に目を通し、該当するすべてのボックスに「x」を入力してください。 -->
- [x] [開発資料](https://mango-garlic-eff.notion.site/KonomiTV-90f4b25555c14b9ba0cf5498e6feb1c3) と [データベース設計](https://mango-garlic-eff.notion.site/KonomiTV-544e02334c89420fa24804ec70f46b6d) は読みましたか？
  - もともと自分用のメモですが、このプロジェクトの開発方針や設計などが記載されています。開発時の参考にしてください。
- [x] Git のコミットメッセージは開発資料に記載のフォーマットになっていますか？（重要）
  - このプロジェクト上のコミットメッセージは、基本的に全てこのフォーマットに従って記述されています（文字数は問いません）。
  - 正しいフォーマットになっていない場合、force push で必ずコミットメッセージを変更してから送信してください。
- [x] このプロジェクトのコーディング規約に従ったコードになっていますか？
  - コーディング規約は開発資料に記載されています。
  - そもそもコーディング規約と言えるほど大層なものではありませんが、一度目を通しておいてください。
- [x] プルリクエストは master ブランチに送信されていますか？
  - release ブランチはリリースした時にしか更新されません。必ず master ブランチに送信してください。

## 説明

NVEncC のコマンドラインに ```--disable-vulkan``` を追加し、KonmiTV 用途では不要な Vulkan 初期化をスキップすることで、起動高速化と安定化を図ります。

なお、本オプションは NVEnc 7.82 ですでに利用可能です。

## 動機とコンテキスト

NVEncでは7.71からLinuxでのlibplaceboライブラリへの対応のため、Linux環境においてVulkanのよるデバイス初期化を追加しました。しかし、この初期化処理は多少の時間を要します。また、環境によってはNVIDIA以外のGPUのVulkanドライバを起因として、稀ですがクラッシュの原因になることもあります。

この変更は、こうした問題を回避するため、KonmiTV用途では不要なVulkan初期化をスキップするよう```--disable-vulkan```を付与するものです。

なお、Windows環境においても```--disable-vulkan```を付与して問題ありません(もともとVulkan初期化を行わないので単に無視されます)。

