### PR TITLE
ハードウェアエンコードで録画再生を行う際のセグメント分割改善

### DIFF
--- a/server/app/streams/VideoEncodingTask.py
+++ b/server/app/streams/VideoEncodingTask.py
@@ -337,6 +337,8 @@ class VideoEncodingTask:
 
         # 出力 TS のタイムスタンプオフセット
         options.append(f'-m output_ts_offset:{output_ts_offset}')
+        # dts 合わせにするため、B フレームによる pts-dts ずれ量を補正する
+        options.append(f'--offset-video-dts-advance')
 
         # 出力
         options.append('--output-format mpegts')  # MPEG-TS 出力ということを明示

--- a/server/app/streams/VideoEncodingTask.py
+++ b/server/app/streams/VideoEncodingTask.py
@@ -306,12 +306,12 @@ class VideoEncodingTask:
             ## インターレース解除 (60i → 30p (フレームレート: 30fps))
             ## NVEncC の --vpp-deinterlace normal は GPU 機種次第では稀に解除漏れのジャギーが入るらしいので、代わりに --vpp-afs を使う
             ## NVIDIA GPU は当然ながら Intel の内蔵 GPU よりも性能が高いので、GPU フィルタを使ってもパフォーマンスに問題はないと判断
-            ## VCEEncC では --vpp-deinterlace 自体が使えないので、代わりに --vpp-afs を使う
+            ## VCEEncC では --vpp-deinterlace 自体が使えないので、代わりに --vpp-afs を使う (ただし、 timestamp を変えないよう coeff_shift=0 を指定する)
             else:
                 if encoder_type == 'QSVEncC':
                     options.append('--vpp-deinterlace normal')
                 elif encoder_type == 'NVEncC' or encoder_type == 'VCEEncC':
-                    options.append('--vpp-afs preset=default')
+                    options.append('--vpp-afs preset=default,coeff_shift=0')
                 elif encoder_type == 'rkmppenc':
                     options.append('--vpp-deinterlace normal_i5')
                 options.append(f'--avsync vfr --gop-len {int(self.GOP_LENGTH_SECOND * 30)}')

--- a/server/app/streams/VideoEncodingTask.py
+++ b/server/app/streams/VideoEncodingTask.py
@@ -600,8 +600,8 @@ class VideoEncodingTask:
                     elif pid == self._video_pid:
                         self._video_parser.push(packet)
                         for video in self._video_parser:
-                            current_timestamp = cast(int, video.dts() or video.pts()) / ts.HZ  # 秒単位
-                            next_segment_start_timestamp = (self._current_segment.start_dts / ts.HZ) + self._current_segment.duration_seconds  # 秒単位
+                            current_timestamp = cast(int, video.dts() or video.pts())
+                            next_segment_start_timestamp = self._current_segment.start_dts + int(self._current_segment.duration_seconds * ts.HZ + 0.5)
 
                             # 次のセグメントの開始時刻以上になったら、現在のセグメントを確定して次のセグメントへ
                             # TODO: 現在の映像 PES がキーフレームかどうかを厳密にチェックしてから、当該 PES 以前まででセグメントを確定するようにする


### PR DESCRIPTION
## 変更の種類
<!-- このプルリクエストではどのような変更が行われますか？ 該当するすべてのボックスに「x」を入力してください。 -->
- [x] 不具合の修正
- [ ] 新しい機能の追加
- [x] 改善・リファクタリング（機能は追加されないが、動作やコードを改善する破壊的でない変更）

## チェックリスト:
<!-- 以下のすべての点に目を通し、該当するすべてのボックスに「x」を入力してください。 -->
- [x] [開発資料](https://mango-garlic-eff.notion.site/KonomiTV-90f4b25555c14b9ba0cf5498e6feb1c3) と [データベース設計](https://mango-garlic-eff.notion.site/KonomiTV-544e02334c89420fa24804ec70f46b6d) は読みましたか？
  - もともと自分用のメモですが、このプロジェクトの開発方針や設計などが記載されています。開発時の参考にしてください。
- [x] Git のコミットメッセージは開発資料に記載のフォーマットになっていますか？（重要）
  - このプロジェクト上のコミットメッセージは、基本的に全てこのフォーマットに従って記述されています（文字数は問いません）。
  - 正しいフォーマットになっていない場合、force push で必ずコミットメッセージを変更してから送信してください。
- [x] このプロジェクトのコーディング規約に従ったコードになっていますか？
  - コーディング規約は開発資料に記載されています。
  - そもそもコーディング規約と言えるほど大層なものではありませんが、一度目を通しておいてください。
- [x] プルリクエストは master ブランチに送信されていますか？
  - release ブランチはリリースした時にしか更新されません。必ず master ブランチに送信してください。

## 説明
3点の変更により、録画再生時のセグメントの先頭がキーフレームとなるよう調整します。

なお、本改変の際には、下記への更新が必要となってしまいますので、ご注意いただければと思います。

- NVEncC 8.01
- QSVEncC 7.84
- VCEEncC 8.33
- rkmppenc 0.14

## 動機とコンテキスト
現状の録画再生では、各セグメントの先頭がキーフレームとは限らない出力となっています。

実際の動作に問題はない場合が多いですが、おそらくシーク時に意図した位置から再生されていない可能性があり、その改善を図ります。

- 9b5cbbb1
  KonomiTVはdtsで分割していますが、エンコーダ出力の先頭は通常ptsを基準とするため、Bフレームの有無によりdts側には指定した```output_ts_offset```からずれが発生します。エンコーダに新設の```--offset-video-dts-advance```オプションにより、このずれをエンコーダ側で補正し、KonomiTV側で狙ったとおりの分割ができるようにします。
  
- 22b36ca2
  vpp-afsはインタレをフィードシフトにより解除することがありますが、この際再生を滑らかにするため、シフトした分だけ1/2フレームタイムスタンプをずらします。しかし、この操作がキーフレームで行われるとタイムスタンプずれにより狙ったとおりの分割ができなくなります。そこで、vpp-afsのオプションに ```coeff_shift=0``` を追加し、vpp-afsのシフトを停止することで、狙ったとおりの分割ができるようにします。
  
- ab0750e4
　KonomiTVではセグメント分割用の時刻比較を小数を用い秒単位で行っていましたが、浮動小数点の微妙な誤差により、キーフレームでタイムスタンプの完全一致が取れず、分割点のキーフレームがひとつ前のセグメントに含まれてしまうことがありました。浮動小数点での比較を整数での比較に変更し、この問題を解消します。

