### PR TITLE
fix: [Client][Account] ログイン・登録ページでホットキー（Enter）対応を追加

### DIFF
--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -15,7 +15,8 @@
                         <v-text-field class="mt-12" color="primary" variant="outlined"
                             placeholder="ユーザー名" hide-details autofocus
                             :density="is_form_dense ? 'compact' : 'default'"
-                            v-model="username">
+                            v-model="username"
+                            @keyup.enter="login()">
                         </v-text-field>
                         <v-text-field class="mt-8" color="primary" variant="outlined"
                             placeholder="パスワード" hide-details
@@ -23,7 +24,8 @@
                             v-model="password"
                             :type="password_showing ? 'text' : 'password'"
                             :append-inner-icon="password_showing ? 'mdi-eye' : 'mdi-eye-off'"
-                            @click:appendInner="password_showing = !password_showing">
+                            @click:appendInner="password_showing = !password_showing"
+                            @keyup.enter="login()">
                         </v-text-field>
                         <v-btn class="login-button mt-5" color="secondary" variant="flat" width="100%" height="56"
                             @click="login()">

--- a/client/src/views/Register.vue
+++ b/client/src/views/Register.vue
@@ -16,7 +16,8 @@
                             placeholder="ユーザー名" autofocus
                             :density="is_form_dense ? 'compact' : 'default'"
                             v-model="username"
-                            :rules="[username_validation]">
+                            :rules="[username_validation]"
+                            @keyup.enter="register()">
                         </v-text-field>
                         <v-text-field style="margin-top: 10px;" color="primary" variant="outlined"
                             placeholder="パスワード"
@@ -25,7 +26,8 @@
                             :type="password_showing ? 'text' : 'password'"
                             :rules="[password_validation]"
                             :append-inner-icon="password_showing ? 'mdi-eye' : 'mdi-eye-off'"
-                            @click:appendInner="password_showing = !password_showing">
+                            @click:appendInner="password_showing = !password_showing"
+                            @keyup.enter="register()">
                         </v-text-field>
                         <v-btn class="register-button mt-5" color="secondary" variant="flat" width="100%" height="56"
                             @click="register()">


### PR DESCRIPTION
## 変更の種類
<!-- このプルリクエストではどのような変更が行われますか？ 該当するすべてのボックスに「x」を入力してください。 -->
- [ ] 不具合の修正
- [ ] 新しい機能の追加
- [x] 改善・リファクタリング（機能は追加されないが、動作やコードを改善する破壊的でない変更）

## チェックリスト:
<!-- 以下のすべての点に目を通し、該当するすべてのボックスに「x」を入力してください。 -->
- [x] [開発資料](https://mango-garlic-eff.notion.site/KonomiTV-90f4b25555c14b9ba0cf5498e6feb1c3) と [データベース設計](https://mango-garlic-eff.notion.site/KonomiTV-544e02334c89420fa24804ec70f46b6d) は読みましたか？
  - もともと自分用のメモですが、このプロジェクトの開発方針や設計などが記載されています。開発時の参考にしてください。
- [x] Git のコミットメッセージは開発資料に記載のフォーマットになっていますか？（重要）
  - このプロジェクト上のコミットメッセージは、基本的に全てこのフォーマットに従って記述されています（文字数は問いません）。
  - 正しいフォーマットになっていない場合、force push で必ずコミットメッセージを変更してから送信してください。
- [x] このプロジェクトのコーディング規約に従ったコードになっていますか？
  - コーディング規約は開発資料に記載されています。
  - そもそもコーディング規約と言えるほど大層なものではありませんが、一度目を通しておいてください。
- [x] プルリクエストは master ブランチに送信されていますか？
  - release ブランチはリリースした時にしか更新されません。必ず master ブランチに送信してください。

## 説明
  1. ~~タブ切り替え時にスクロール位置を記憶・復元する機能を追加~~
  2. ログイン・登録ページでホットキー（Enter）対応を追加
## 動機とコンテキスト
~~チャンネルタブを切り替える際、各タブで閲覧していたスクロール位置が保持されず、前のタブの高さ位置のまま表示されてしまう問題がありました。~~
> ~~ 例えば、CSタブで下の方までスクロールした後に地上波タブに切り替えると、地上波タブでも ~~同じスクロール位置~~ 最下部から表示が開始され、適切な位置から閲覧を開始できませんでした。 ~~

https://github.com/user-attachments/assets/7826cb38-4a32-4dba-abb3-343a9a87d19c


~~修正後：  ~~

https://github.com/user-attachments/assets/bf21b151-0092-4153-b63c-31f046b167b5




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - ログイン画面と登録画面で、ユーザー名・パスワード入力中にEnterキーで送信できるようになりました。マウス操作なしで素早く認証フローを完了でき、キーボード中心の操作性が向上します。
  - パスワード欄の表示切替など既存の動作はそのまま維持しつつ、Enterキーでの送信操作を追加し、両画面で一貫した入力体験を提供します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->