### PR TITLE
通信節約モード使用時の QSVEnc/NVEnc の設定を調整

### DIFF
--- a/server/app/streams/LiveEncodingTask.py
+++ b/server/app/streams/LiveEncodingTask.py
@@ -347,7 +347,8 @@ class LiveEncodingTask:
         ## H.265/HEVC の高圧縮化調整
         if QUALITY[quality].is_hevc is True:
             if encoder_type == 'QSVEncC':
-                options.append('--qvbr-quality 30')
+                options.append('--qvbr-quality 20 --extbrc --mbbrc --scenario-info game_streaming --tune perceptual')
+                options.append('--i-adapt --b-adapt --b-pyramid --weightp --weightb --adapt-ref --adapt-ltr --adapt-cqm')
             elif encoder_type == 'NVEncC':
                 options.append('--qp-min 23:26:30 --lookahead 16 --multipass 2pass-full --weightp --bref-mode middle --aq --aq-temporal')
 

--- a/server/app/streams/LiveEncodingTask.py
+++ b/server/app/streams/LiveEncodingTask.py
@@ -350,7 +350,8 @@ class LiveEncodingTask:
                 options.append('--qvbr-quality 20 --extbrc --mbbrc --scenario-info game_streaming --tune perceptual')
                 options.append('--i-adapt --b-adapt --b-pyramid --weightp --weightb --adapt-ref --adapt-ltr --adapt-cqm')
             elif encoder_type == 'NVEncC':
-                options.append('--qp-min 23:26:30 --lookahead 16 --multipass 2pass-full --weightp --bref-mode middle --aq --aq-temporal')
+                # --weightp は過去の GPU 世代で不安定な場合があるので使用しない
+                options.append('--qp-min 23:26:30 --lookahead 16 --multipass 2pass-full --bref-mode middle --aq --aq-temporal')
 
         ## ヘッダ情報制御 (GOP ごとにヘッダを再送する)
         ## VCEEncC ではデフォルトで有効であり、当該オプションは存在しない

--- a/server/app/streams/VideoEncodingTask.py
+++ b/server/app/streams/VideoEncodingTask.py
@@ -261,7 +261,8 @@ class VideoEncodingTask:
         ## H.265/HEVC の高圧縮化調整
         if QUALITY[quality].is_hevc is True:
             if encoder_type == 'QSVEncC':
-                options.append('--qvbr-quality 30')
+                options.append('--qvbr-quality 20 --extbrc --mbbrc --scenario-info game_streaming --tune perceptual')
+                options.append('--i-adapt --b-adapt --b-pyramid --weightp --weightb --adapt-ref --adapt-ltr --adapt-cqm')
             elif encoder_type == 'NVEncC':
                 options.append('--qp-min 23:26:30 --lookahead 16 --multipass 2pass-full --weightp --bref-mode middle --aq --aq-temporal')
 

--- a/server/app/streams/VideoEncodingTask.py
+++ b/server/app/streams/VideoEncodingTask.py
@@ -264,7 +264,8 @@ class VideoEncodingTask:
                 options.append('--qvbr-quality 20 --extbrc --mbbrc --scenario-info game_streaming --tune perceptual')
                 options.append('--i-adapt --b-adapt --b-pyramid --weightp --weightb --adapt-ref --adapt-ltr --adapt-cqm')
             elif encoder_type == 'NVEncC':
-                options.append('--qp-min 23:26:30 --lookahead 16 --multipass 2pass-full --weightp --bref-mode middle --aq --aq-temporal')
+                # --weightp は過去の GPU 世代で不安定な場合があるので使用しない
+                options.append('--qp-min 23:26:30 --lookahead 16 --multipass 2pass-full --bref-mode middle --aq --aq-temporal')
 
         ## ヘッダ情報制御 (GOP ごとにヘッダを再送する)
         ## VCEEncC ではデフォルトで有効であり、当該オプションは存在しない


### PR DESCRIPTION
## 変更の種類
<!-- このプルリクエストではどのような変更が行われますか？ 該当するすべてのボックスに「x」を入力してください。 -->
- [ ] 不具合の修正
- [ ] 新しい機能の追加
- [x] 改善・リファクタリング（機能は追加されないが、動作やコードを改善する破壊的でない変更）

## チェックリスト:
<!-- 以下のすべての点に目を通し、該当するすべてのボックスに「x」を入力してください。 -->
- [x] [開発資料](https://mango-garlic-eff.notion.site/KonomiTV-90f4b25555c14b9ba0cf5498e6feb1c3) と [データベース設計](https://mango-garlic-eff.notion.site/KonomiTV-544e02334c89420fa24804ec70f46b6d) は読みましたか？
  - もともと自分用のメモですが、このプロジェクトの開発方針や設計などが記載されています。開発時の参考にしてください。
- [x] Git のコミットメッセージは開発資料に記載のフォーマットになっていますか？（重要）
  - このプロジェクト上のコミットメッセージは、基本的に全てこのフォーマットに従って記述されています（文字数は問いません）。
  - 正しいフォーマットになっていない場合、force push で必ずコミットメッセージを変更してから送信してください。
- [x] このプロジェクトのコーディング規約に従ったコードになっていますか？
  - コーディング規約は開発資料に記載されています。
  - そもそもコーディング規約と言えるほど大層なものではありませんが、一度目を通しておいてください。
- [x] プルリクエストは master ブランチに送信されていますか？
  - release ブランチはリリースした時にしか更新されません。必ず master ブランチに送信してください。

## 説明
エンコーダオプションの調整により、高画質化・安定化を図ります。
 
## 詳細
- QSVEnc
  - HEVC で高画質化するオプションを追加し、品質向上を図ります。
    - これらオプションを利用できない過去世代の GPU では自動的に無効化されるので共通で指定できます。
  - また、少し高圧縮寄りになりすぎていたので、```--qvbr-quality 30->20```に値を調整します。

- NVEnc
  - 過去世代の GPU (GTX10xx など) で HEVC エンコード時に ```--weightp``` は使用できるのですが、使用するとエンコード途中でたまにエラーになるので、使用を中止し、安定化を図ります。

- VCEEnc
  - 高画質化オプションを指定すると Vega 世代等で不安定になったりするので変更しません…

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新機能
  * Intel QSV 使用時の HEVC ハードウェアエンコードを強化。拡張BRC/MBRC、シーン適応、perceptualチューニング、各種アダプティブ設定により、同等ビットレートでの画質と動きへの追従性を向上。
  * NVIDIA NVEnc 使用時は既存のHEVC設定を維持。古いGPUでのweightp不安定性に配慮した調整だが、エンコード挙動の変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->