### PR TITLE
Fix: [Server][MetadataAnalyzer] duration が正しく取得できない問題を修正

### DIFF
--- a/server/app/metadata/MetadataAnalyzer.py
+++ b/server/app/metadata/MetadataAnalyzer.py
@@ -302,9 +302,6 @@ class MetadataAnalyzer:
             container_format = 'MPEG-TS'
         elif 'mp4' in full_probe.format.format_name:
             container_format = 'MPEG-4'
-        ## 再生時間
-        if full_probe.format.duration is not None:
-            duration = float(full_probe.format.duration)
 
         ## 部分解析: 映像・音声情報を取得
         is_video_track_analyzed = False
@@ -326,6 +323,12 @@ class MetadataAnalyzer:
         if len(sample_probe_video_streams) == 0 and len(sample_probe_audio_streams) == 0:
             logging.warning(f'{self.recorded_file_path}: No valid video or audio streams found.')
             return None
+            
+        ## 再生時間
+        if full_probe_video_streams[0].duration is not None:
+            duration = full_probe_video_streams[0].duration
+        elif full_probe.format.duration is not None:
+            duration = float(full_probe.format.duration)
 
         ## 映像情報
         for video_stream in sample_probe_video_streams:


### PR DESCRIPTION
## 変更の種類
<!-- このプルリクエストではどのような変更が行われますか？ 該当するすべてのボックスに「x」を入力してください。 -->
- [x] 不具合の修正
- [ ] 新しい機能の追加
- [ ] 改善・リファクタリング（機能は追加されないが、動作やコードを改善する破壊的でない変更）

## チェックリスト:
<!-- 以下のすべての点に目を通し、該当するすべてのボックスに「x」を入力してください。 -->
- [x] [開発資料](https://mango-garlic-eff.notion.site/KonomiTV-90f4b25555c14b9ba0cf5498e6feb1c3) と [データベース設計](https://mango-garlic-eff.notion.site/KonomiTV-544e02334c89420fa24804ec70f46b6d) は読みましたか？
  - もともと自分用のメモですが、このプロジェクトの開発方針や設計などが記載されています。開発時の参考にしてください。
- [x] Git のコミットメッセージは開発資料に記載のフォーマットになっていますか？（重要）
  - このプロジェクト上のコミットメッセージは、基本的に全てこのフォーマットに従って記述されています（文字数は問いません）。
  - 正しいフォーマットになっていない場合、force push で必ずコミットメッセージを変更してから送信してください。
- [x] このプロジェクトのコーディング規約に従ったコードになっていますか？
  - コーディング規約は開発資料に記載されています。
  - そもそもコーディング規約と言えるほど大層なものではありませんが、一度目を通しておいてください。
- [x] プルリクエストは master ブランチに送信されていますか？
  - release ブランチはリリースした時にしか更新されません。必ず master ブランチに送信してください。

## 説明
<!-- このプルリクエストでの変更点を詳しく説明してください。 -->

duration が正しい値になるように修正

## 動機とコンテキスト
<!-- この変更はなぜ必要ですか？どのような問題が解決されますか？ -->
<!-- この変更で未解決の Issue が修正される場合は、ここにリンクを貼ってください。 -->



ffprobe は一番長いstreamのdurationを返してしまうのでstreamの動画のdurationを利用するように変更した
epgのdurationが何故か非常にでかいことがあるのでそれに引っ張られてしまう
特に`analyzeduration`が大きいとepgまでしっかりパースしてしまう


以下の動画はhevcにtsreplaceされたものである点に注意、6483秒ではなく1815秒が期待される

```sh
➜  KonomiTV git:(fix-duration) ffprobe -hide_banner -loglevel error -analyzeduration 30000000 -probesize 80M -show_format -show_streams -show_programs -of json '/home/yuki/recordings/TV-Encoded/ドキュメント72時間 選 函館 ハンバーガーと幸せと[解][字].hevc.ts'  
{
[aac @ 0x5665e30832c0] channel element 2.5 is not allocated
[aac @ 0x5665e30832c0] Pulse tool not allowed in eight short sequence.
    "programs": [
        {
            "program_id": 61440,
            "program_num": 61440,
            "nb_streams": 5,
            "pmt_pid": 496,
            "pcr_pid": 511,
            "tags": {
                "service_name": "\u000eNHK\u000fAm9g\u000e1�\u000fBgJ,",
                "service_provider": ""
            },
            "streams": [
                {
                    "index": 0,
                    "codec_name": "hevc",
                    "codec_long_name": "H.265 / HEVC (High Efficiency Video Coding)",
                    "profile": "Main",
                    "codec_type": "video",
                    "codec_tag_string": "[36][0][0][0]",
                    "codec_tag": "0x0024",
                    "width": 1440,
                    "height": 1080,
                    "coded_width": 1440,
                    "coded_height": 1080,
                    "has_b_frames": 4,
                    "sample_aspect_ratio": "4:3",
                    "display_aspect_ratio": "16:9",
                    "pix_fmt": "yuv420p",
                    "level": 120,
                    "color_range": "tv",
                    "color_space": "bt709",
                    "color_transfer": "bt709",
                    "color_primaries": "bt709",
                    "chroma_location": "left",
                    "refs": 1,
                    "view_ids_available": "",
                    "view_pos_available": "",
                    "ts_id": "31792",
                    "ts_packetsize": "188",
                    "id": "0x100",
                    "r_frame_rate": "30000/1001",
                    "avg_frame_rate": "30000/1001",
                    "time_base": "1/90000",
                    "start_pts": 8557455989,
                    "start_time": "95082.844322",
                    "duration_ts": 163324161,
                    "duration": "1814.712900",
                    "extradata_size": 112,
                    "disposition": {
                        "default": 0,
                        "dub": 0,
                        "original": 0,
                        "comment": 0,
                        "lyrics": 0,
                        "karaoke": 0,
                        "forced": 0,
                        "hearing_impaired": 0,
                        "visual_impaired": 0,
                        "clean_effects": 0,
                        "attached_pic": 0,
                        "timed_thumbnails": 0,
                        "non_diegetic": 0,
                        "captions": 0,
                        "descriptions": 0,
                        "metadata": 0,
                        "dependent": 0,
                        "still_image": 0,
                        "multilayer": 0
                    }
                },
                {
                    "index": 1,
                    "codec_name": "aac",
                    "codec_long_name": "AAC (Advanced Audio Coding)",
                    "profile": "LC",
                    "codec_type": "audio",
                    "codec_tag_string": "[15][0][0][0]",
                    "codec_tag": "0x000f",
                    "sample_fmt": "fltp",
                    "sample_rate": "48000",
                    "channels": 2,
                    "channel_layout": "stereo",
                    "bits_per_sample": 0,
                    "initial_padding": 0,
                    "ts_id": "31792",
                    "ts_packetsize": "188",
                    "id": "0x110",
                    "r_frame_rate": "0/0",
                    "avg_frame_rate": "0/0",
                    "time_base": "1/90000",
                    "start_pts": 8557394900,
                    "start_time": "95082.165556",
                    "duration_ts": 163359360,
                    "duration": "1815.104000",
                    "bit_rate": "144126",
                    "disposition": {
                        "default": 0,
                        "dub": 0,
                        "original": 0,
                        "comment": 0,
                        "lyrics": 0,
                        "karaoke": 0,
                        "forced": 0,
                        "hearing_impaired": 0,
                        "visual_impaired": 0,
                        "clean_effects": 0,
                        "attached_pic": 0,
                        "timed_thumbnails": 0,
                        "non_diegetic": 0,
                        "captions": 0,
                        "descriptions": 0,
                        "metadata": 0,
                        "dependent": 0,
                        "still_image": 0,
                        "multilayer": 0
                    }
                },
                {
                    "index": 2,
                    "codec_name": "arib_caption",
                    "codec_long_name": "ARIB STD-B24 caption",
                    "profile": "Profile A",
                    "codec_type": "subtitle",
                    "codec_tag_string": "[6][0][0][0]",
                    "codec_tag": "0x0006",
                    "ts_id": "31792",
                    "ts_packetsize": "188",
                    "id": "0x130",
                    "r_frame_rate": "0/0",
                    "avg_frame_rate": "0/0",
                    "time_base": "1/90000",
                    "start_pts": 8557486050,
                    "start_time": "95083.178333",
                    "disposition": {
                        "default": 0,
                        "dub": 0,
                        "original": 0,
                        "comment": 0,
                        "lyrics": 0,
                        "karaoke": 0,
                        "forced": 0,
                        "hearing_impaired": 0,
                        "visual_impaired": 0,
                        "clean_effects": 0,
                        "attached_pic": 0,
                        "timed_thumbnails": 0,
                        "non_diegetic": 0,
                        "captions": 0,
                        "descriptions": 0,
                        "metadata": 0,
                        "dependent": 0,
                        "still_image": 0,
                        "multilayer": 0
                    }
                },
                {
                    "index": 3,
                    "codec_name": "bin_data",
                    "codec_long_name": "binary data",
                    "codec_type": "data",
                    "codec_tag_string": "[6][0][0][0]",
                    "codec_tag": "0x0006",
                    "ts_id": "31792",
                    "ts_packetsize": "188",
                    "id": "0x138",
                    "r_frame_rate": "0/0",
                    "avg_frame_rate": "0/0",
                    "time_base": "1/90000",
                    "start_pts": 8137250900,
                    "start_time": "90413.898889",
                    "duration_ts": 583529250,
                    "duration": "6483.658333",
                    "disposition": {
                        "default": 0,
                        "dub": 0,
                        "original": 0,
                        "comment": 0,
                        "lyrics": 0,
                        "karaoke": 0,
                        "forced": 0,
                        "hearing_impaired": 0,
                        "visual_impaired": 0,
                        "clean_effects": 0,
                        "attached_pic": 0,
                        "timed_thumbnails": 0,
                        "non_diegetic": 0,
                        "captions": 0,
                        "descriptions": 0,
                        "metadata": 0,
                        "dependent": 0,
                        "still_image": 0,
                        "multilayer": 0
                    }
                },
                {
                    "index": 5,
                    "codec_name": "aac",
                    "codec_long_name": "AAC (Advanced Audio Coding)",
                    "profile": "LC",
                    "codec_type": "audio",
                    "codec_tag_string": "[15][0][0][0]",
                    "codec_tag": "0x000f",
                    "sample_fmt": "fltp",
                    "sample_rate": "48000",
                    "channels": 2,
                    "channel_layout": "stereo",
                    "bits_per_sample": 0,
                    "initial_padding": 0,
                    "ts_id": "31792",
                    "ts_packetsize": "188",
                    "id": "0x111",
                    "r_frame_rate": "0/0",
                    "avg_frame_rate": "0/0",
                    "time_base": "1/90000",
                    "start_pts": 8137250900,
                    "start_time": "90413.898889",
                    "bit_rate": "144226",
                    "disposition": {
                        "default": 0,
                        "dub": 0,
                        "original": 0,
                        "comment": 0,
                        "lyrics": 0,
                        "karaoke": 0,
                        "forced": 0,
                        "hearing_impaired": 0,
                        "visual_impaired": 0,
                        "clean_effects": 0,
                        "attached_pic": 0,
                        "timed_thumbnails": 0,
                        "non_diegetic": 0,
                        "captions": 0,
                        "descriptions": 0,
                        "metadata": 0,
                        "dependent": 0,
                        "still_image": 0,
                        "multilayer": 0
                    }
                }
            ]
        },
        {
            "program_id": 61441,
            "program_num": 0,
            "nb_streams": 0,
            "pmt_pid": 0,
            "pcr_pid": 0,
            "tags": {
                "service_name": "\u000eNHK\u000fAm9g\u000e2�\u000fBgJ,",
                "service_provider": ""
            },
            "streams": [

            ]
        },
        {
            "program_id": 61824,
            "program_num": 0,
            "nb_streams": 0,
            "pmt_pid": 0,
            "pcr_pid": 0,
            "tags": {
                "service_name": "\u000eNHK\u000f7HBS\u000eG�\u000fBgJ,",
                "service_provider": ""
            },
            "streams": [

            ]
        }
    ],
    "streams": [
        {
            "index": 0,
            "codec_name": "hevc",
            "codec_long_name": "H.265 / HEVC (High Efficiency Video Coding)",
            "profile": "Main",
            "codec_type": "video",
            "codec_tag_string": "[36][0][0][0]",
            "codec_tag": "0x0024",
            "width": 1440,
            "height": 1080,
            "coded_width": 1440,
            "coded_height": 1080,
            "has_b_frames": 4,
            "sample_aspect_ratio": "4:3",
            "display_aspect_ratio": "16:9",
            "pix_fmt": "yuv420p",
            "level": 120,
            "color_range": "tv",
            "color_space": "bt709",
            "color_transfer": "bt709",
            "color_primaries": "bt709",
            "chroma_location": "left",
            "refs": 1,
            "view_ids_available": "",
            "view_pos_available": "",
            "ts_id": "31792",
            "ts_packetsize": "188",
            "id": "0x100",
            "r_frame_rate": "30000/1001",
            "avg_frame_rate": "30000/1001",
            "time_base": "1/90000",
            "start_pts": 8557455989,
            "start_time": "95082.844322",
            "duration_ts": 163324161,
            "duration": "1814.712900",
            "extradata_size": 112,
            "disposition": {
                "default": 0,
                "dub": 0,
                "original": 0,
                "comment": 0,
                "lyrics": 0,
                "karaoke": 0,
                "forced": 0,
                "hearing_impaired": 0,
                "visual_impaired": 0,
                "clean_effects": 0,
                "attached_pic": 0,
                "timed_thumbnails": 0,
                "non_diegetic": 0,
                "captions": 0,
                "descriptions": 0,
                "metadata": 0,
                "dependent": 0,
                "still_image": 0,
                "multilayer": 0
            }
        },
        {
            "index": 1,
            "codec_name": "aac",
            "codec_long_name": "AAC (Advanced Audio Coding)",
            "profile": "LC",
            "codec_type": "audio",
            "codec_tag_string": "[15][0][0][0]",
            "codec_tag": "0x000f",
            "sample_fmt": "fltp",
            "sample_rate": "48000",
            "channels": 2,
            "channel_layout": "stereo",
            "bits_per_sample": 0,
            "initial_padding": 0,
            "ts_id": "31792",
            "ts_packetsize": "188",
            "id": "0x110",
            "r_frame_rate": "0/0",
            "avg_frame_rate": "0/0",
            "time_base": "1/90000",
            "start_pts": 8557394900,
            "start_time": "95082.165556",
            "duration_ts": 163359360,
            "duration": "1815.104000",
            "bit_rate": "144126",
            "disposition": {
                "default": 0,
                "dub": 0,
                "original": 0,
                "comment": 0,
                "lyrics": 0,
                "karaoke": 0,
                "forced": 0,
                "hearing_impaired": 0,
                "visual_impaired": 0,
                "clean_effects": 0,
                "attached_pic": 0,
                "timed_thumbnails": 0,
                "non_diegetic": 0,
                "captions": 0,
                "descriptions": 0,
                "metadata": 0,
                "dependent": 0,
                "still_image": 0,
                "multilayer": 0
            }
        },
        {
            "index": 2,
            "codec_name": "arib_caption",
            "codec_long_name": "ARIB STD-B24 caption",
            "profile": "Profile A",
            "codec_type": "subtitle",
            "codec_tag_string": "[6][0][0][0]",
            "codec_tag": "0x0006",
            "ts_id": "31792",
            "ts_packetsize": "188",
            "id": "0x130",
            "r_frame_rate": "0/0",
            "avg_frame_rate": "0/0",
            "time_base": "1/90000",
            "start_pts": 8557486050,
            "start_time": "95083.178333",
            "disposition": {
                "default": 0,
                "dub": 0,
                "original": 0,
                "comment": 0,
                "lyrics": 0,
                "karaoke": 0,
                "forced": 0,
                "hearing_impaired": 0,
                "visual_impaired": 0,
                "clean_effects": 0,
                "attached_pic": 0,
                "timed_thumbnails": 0,
                "non_diegetic": 0,
                "captions": 0,
                "descriptions": 0,
                "metadata": 0,
                "dependent": 0,
                "still_image": 0,
                "multilayer": 0
            }
        },
        {
            "index": 3,
            "codec_name": "bin_data",
            "codec_long_name": "binary data",
            "codec_type": "data",
            "codec_tag_string": "[6][0][0][0]",
            "codec_tag": "0x0006",
            "ts_id": "31792",
            "ts_packetsize": "188",
            "id": "0x138",
            "r_frame_rate": "0/0",
            "avg_frame_rate": "0/0",
            "time_base": "1/90000",
            "start_pts": 8137250900,
            "start_time": "90413.898889",
            "duration_ts": 583529250,
            "duration": "6483.658333",
            "disposition": {
                "default": 0,
                "dub": 0,
                "original": 0,
                "comment": 0,
                "lyrics": 0,
                "karaoke": 0,
                "forced": 0,
                "hearing_impaired": 0,
                "visual_impaired": 0,
                "clean_effects": 0,
                "attached_pic": 0,
                "timed_thumbnails": 0,
                "non_diegetic": 0,
                "captions": 0,
                "descriptions": 0,
                "metadata": 0,
                "dependent": 0,
                "still_image": 0,
                "multilayer": 0
            }
        },
        {
            "index": 4,
            "codec_name": "epg",
            "codec_long_name": "Electronic Program Guide",
            "codec_type": "data",
            "codec_tag_string": "[0][0][0][0]",
            "codec_tag": "0x0000",
            "ts_id": "31792",
            "ts_packetsize": "188",
            "id": "0x12",
            "r_frame_rate": "0/0",
            "avg_frame_rate": "0/0",
            "time_base": "1/90000",
            "start_pts": 8137250900,
            "start_time": "90413.898889",
            "duration_ts": 583529250,
            "duration": "6483.658333",
            "disposition": {
                "default": 0,
                "dub": 0,
                "original": 0,
                "comment": 0,
                "lyrics": 0,
                "karaoke": 0,
                "forced": 0,
                "hearing_impaired": 0,
                "visual_impaired": 0,
                "clean_effects": 0,
                "attached_pic": 0,
                "timed_thumbnails": 0,
                "non_diegetic": 0,
                "captions": 0,
                "descriptions": 0,
                "metadata": 0,
                "dependent": 0,
                "still_image": 0,
                "multilayer": 0
            }
        },
        {
            "index": 5,
            "codec_name": "aac",
            "codec_long_name": "AAC (Advanced Audio Coding)",
            "profile": "LC",
            "codec_type": "audio",
            "codec_tag_string": "[15][0][0][0]",
            "codec_tag": "0x000f",
            "sample_fmt": "fltp",
            "sample_rate": "48000",
            "channels": 2,
            "channel_layout": "stereo",
            "bits_per_sample": 0,
            "initial_padding": 0,
            "ts_id": "31792",
            "ts_packetsize": "188",
            "id": "0x111",
            "r_frame_rate": "0/0",
            "avg_frame_rate": "0/0",
            "time_base": "1/90000",
            "start_pts": 8137250900,
            "start_time": "90413.898889",
            "bit_rate": "144226",
            "disposition": {
                "default": 0,
                "dub": 0,
                "original": 0,
                "comment": 0,
                "lyrics": 0,
                "karaoke": 0,
                "forced": 0,
                "hearing_impaired": 0,
                "visual_impaired": 0,
                "clean_effects": 0,
                "attached_pic": 0,
                "timed_thumbnails": 0,
                "non_diegetic": 0,
                "captions": 0,
                "descriptions": 0,
                "metadata": 0,
                "dependent": 0,
                "still_image": 0,
                "multilayer": 0
            }
        }
    ],
    "format": {
        "filename": "/home/yuki/recordings/TV-Encoded/ドキュメント72時間 選 函館 ハンバーガーと幸せと[解][字].hevc.ts",
        "nb_streams": 6,
        "nb_programs": 3,
        "nb_stream_groups": 0,
        "format_name": "mpegts",
        "format_long_name": "MPEG-TS (MPEG-2 Transport Stream)",
        "start_time": "90413.898889",
        "duration": "6483.658333",
        "size": "925347280",
        "bit_rate": "1141759",
        "probe_score": 50
    }
}
```
