### PR TITLE
Fix: [Client][Player/CaptureManager] Document Picture-in-Picture でキャプチャをクリップボードにコピーできない不具合を修正

### DIFF
--- a/client/src/services/player/managers/CaptureManager.ts
+++ b/client/src/services/player/managers/CaptureManager.ts
@@ -482,8 +482,10 @@ class CaptureManager implements PlayerManager {
                         // Document Picture-in-Picture ウインドウにフォーカスがある場合、メインウインドウの
                         // navigator.clipboard を使うと NotAllowedError が発生するため、PiP ウインドウ側の
                         // Clipboard API を使う
-                        if (('documentPictureInPicture' in window) && documentPictureInPicture.window !== null) {
-                            await documentPictureInPicture.window.navigator.clipboard.write([
+                        const document_pip_window = ('documentPictureInPicture' in window) ?
+                            documentPictureInPicture.window : null;
+                        if (document_pip_window !== null && document_pip_window.document.hasFocus()) {
+                            await document_pip_window.navigator.clipboard.write([
                                 new ClipboardItem({[png_capture.type]: png_capture}),
                             ]);
                         } else {

--- a/client/src/services/player/managers/CaptureManager.ts
+++ b/client/src/services/player/managers/CaptureManager.ts
@@ -478,7 +478,17 @@ class CaptureManager implements PlayerManager {
             for (const capture of [result.capture_normal, result.capture_caption]) {
                 if (capture !== null) {
                     try {
-                        await copyBlobToClipboard(await convertBlobToPng(capture));
+                        const png_capture = await convertBlobToPng(capture);
+                        // Document Picture-in-Picture ウインドウにフォーカスがある場合、メインウインドウの
+                        // navigator.clipboard を使うと NotAllowedError が発生するため、PiP ウインドウ側の
+                        // Clipboard API を使う
+                        if (('documentPictureInPicture' in window) && documentPictureInPicture.window !== null) {
+                            await documentPictureInPicture.window.navigator.clipboard.write([
+                                new ClipboardItem({[png_capture.type]: png_capture}),
+                            ]);
+                        } else {
+                            await copyBlobToClipboard(png_capture);
+                        }
                     } catch (error) {
                         this.player.notice('クリップボードへのキャプチャのコピーに失敗しました。', undefined, undefined, '#FF6F6A');
                         console.error(error);


### PR DESCRIPTION
## 変更の種類

- [x] 不具合の修正
- [ ] 新しい機能の追加
- [ ] 改善・リファクタリング（機能は追加されないが、動作やコードを改善する破壊的でない変更）

## チェックリスト:

- [x] [開発資料](https://mango-garlic-eff.notion.site/KonomiTV-90f4b25555c14b9ba0cf5498e6feb1c3) と [データベース設計](https://mango-garlic-eff.notion.site/KonomiTV-544e02334c89420fa24804ec70f46b6d) は読みましたか？
- [x] Git のコミットメッセージは開発資料に記載のフォーマットになっていますか？（重要）
- [x] このプロジェクトのコーディング規約に従ったコードになっていますか？
- [x] プルリクエストは master ブランチに送信されていますか？

## 説明

「キャプチャをクリップボードにコピーする」設定が有効になっている状態で Document Picture-in-Picture での再生中にキャプチャを行った際、クリップボードへのコピーに失敗し、「クリップボードへのキャプチャのコピーに失敗しました。」と出る問題を修正しました。

Document Picture-in-Picture ウインドウが開いている場合は、PiP ウインドウ側の Clipboard API を使用してキャプチャ画像を書き込みます。通常の再生時は、これまでどおりメインウインドウ側の処理を使用します。

## 動機とコンテキスト

Document Picture-in-Picture ではユーザー操作のフォーカスが PiP ウインドウ側にあるため、メインウインドウの `navigator.clipboard` を使用すると `NotAllowedError` が発生し、クリップボードへのコピーに失敗していました。

キャプチャ画像を PNG に変換した後、Document Picture-in-Picture ウインドウが存在する場合のみ、そのウインドウの `navigator.clipboard.write()` を使用するように変更しています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * キャプチャ画像を PNG 形式に変換してから、クリップボードへコピーするよう改善しました。
  * PiP（ピクチャー・イン・ピクチャー）ウィンドウが利用可能で、なおかつフォーカス中の場合は PiP 側のクリップボードへ書き込みます。
  * それ以外の場合は、従来どおり通常の方法でクリップボードへコピーします。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->