### PR TITLE
Update: [Server][Streams/EncodingTask] HWEncC の可変解像度対応を反映。

### DIFF
--- a/server/app/metadata/MetadataAnalyzer.py
+++ b/server/app/metadata/MetadataAnalyzer.py
@@ -879,10 +879,8 @@ class MetadataAnalyzer:
         base_stream_info = stream_infos[0][1]
         for sample_ratio, stream_info in stream_infos[1:]:
             # 映像 PID や映像ストリーム構成が途中で変わる録画（マルチ編成開始/終了での解像度変更時など）に関して、
-            # HWEncC 系エンコーダーは --avhw だと録画マージン区間 -> 本編での解像度切り替えに対応できずクラッシュし、
-            # --avsw の場合はエラーこそ出ないがデコードがめちゃくちゃになる問題がある
-            ## 録画ファイル自体の代表解像度は 25% 位置の FFprobe サンプルから取得済みなので、ここではエンコーダー選択用のフラグのみ決める
-            ## この関数の戻り値が RecordedVideo.has_video_stream_changes に反映され、True の場合は再生時エンコーダーが FFmpeg に固定される
+            # サムネイル生成や解析時の注意喚起に使うフラグを立てる
+            ## 録画ファイル自体の代表解像度は 25% 位置の FFprobe サンプルから取得済みなので、ここでは変化検出のみ行う
             if (
                 stream_info.video_pid != base_stream_info.video_pid or
                 stream_info.codec != base_stream_info.codec

--- a/server/app/streams/LiveEncodingTask.py
+++ b/server/app/streams/LiveEncodingTask.py
@@ -311,6 +311,14 @@ class LiveEncodingTask:
         ## QSVEncC・NVEncC・rkmppenc は HW デコーダーを利用する
         else:
             options.append('--avhw')
+        ## 入力途中の解像度変更に備えて、デコーダー/入力サーフェスの最大確保解像度を指定する
+        ## --output-res は出力側の固定解像度であり、こちらは入力側の上限なので併用する
+        ## BS4K は入力が 4K のため 3840×2160、それ以外のチャンネルは HD 上限の 1920×1080 とする
+        ## (画質プリセットの出力解像度とは独立で、入力に現れうる最大解像度を確保する必要がある)
+        if channel_type == 'BS4K':
+            options.append('--adapt-resolution 3840x2160')
+        else:
+            options.append('--adapt-resolution 1920x1080')
 
         # ストリームのマッピング
         ## 音声切り替えのため、主音声・副音声両方をエンコード後の TS に含む
@@ -1263,8 +1271,7 @@ class LiveEncodingTask:
                         if program_following is not None:
 
                             # 現在の番組のタイトルをログに出力
-                            ## TODO: 番組の解像度が変わった際にエンコーダーがクラッシュorフリーズする可能性があるが、
-                            ## その場合はここでエンコードタスクを再起動させる必要があるかも
+                            ## 番組の解像度が変わった場合は HWEncC の --adapt-resolution でデコーダー側が追従する想定
                             logging.info(f'{self.live_stream.log_prefix} Title: {program_following.title}')
 
                         program_present = program_following

--- a/server/app/streams/VideoEncodingTask.py
+++ b/server/app/streams/VideoEncodingTask.py
@@ -230,6 +230,16 @@ class VideoEncodingTask:
         ## QSVEncC・NVEncC・rkmppenc は HW デコーダーを利用する
         else:
             options.append('--avhw')
+        ## 入力途中の解像度変更に備えて、デコーダー/入力サーフェスの最大確保解像度を指定する
+        ## --output-res は出力側の固定解像度であり、こちらは入力側の上限なので併用する
+        ## 代表解像度が 4K 相当なら 3840×2160、それ以外は HD 上限の 1920×1080 とする
+        ## (ファイル中の最大解像度は持っていないため、HD/4K の天井値で確保する)
+        recorded_video = self.video_stream.recorded_program.recorded_video
+        if (recorded_video.video_resolution_width >= 3840 or
+            recorded_video.video_resolution_height >= 2160):
+            options.append('--adapt-resolution 3840x2160')
+        else:
+            options.append('--adapt-resolution 1920x1080')
 
         # ストリームのマッピング
         ## 音声切り替えのため、主音声・副音声両方をエンコード後の TS に含む
@@ -397,22 +407,6 @@ class VideoEncodingTask:
         # エンコーダーの種類を取得
         CONFIG = Config()
         ENCODER_TYPE = CONFIG.general.encoder
-
-        # 映像 PID や映像ストリーム構成が途中で変わる録画（マルチ編成開始/終了での解像度変更時など）に関して、HWEncC 系エンコーダーは
-        # --avhw だと録画マージン区間 -> 本編での解像度切り替えに対応できずクラッシュし、--avsw の場合はエラーこそ出ないがデコードがめちゃくちゃになる問題がある
-        # このため苦肉の策として、メタデータ解析時に映像構成がイレギュラーな TS だと事前に検出した上で、それらの録画ファイルの再生時エンコーダーを FFmpeg に固定する
-        ## FFmpeg (ソフトウェアデコード/エンコード) + tsreadex (映像 PID 固定化) の構成であれば、解像度変化のある TS も問題なくエンコードできるっぽい
-        recorded_video = self.video_stream.recorded_program.recorded_video
-        if (
-            recorded_video.container_format == 'MPEG-TS' and
-            recorded_video.has_video_stream_changes is True and
-            ENCODER_TYPE != 'FFmpeg'
-        ):
-            logging.warning(
-                f'{self.video_stream.log_prefix} FFmpeg will be used because video stream changes were detected. '
-                f'[configured_encoder: {ENCODER_TYPE}]'
-            )
-            ENCODER_TYPE = 'FFmpeg'
 
         # 新しいエンコードタスクを起動させた時点で既にエンコード済みのセグメントは使えなくなるので、すべてリセットする
         for segment in self.video_stream.segments:


### PR DESCRIPTION
## 変更の種類
<!-- このプルリクエストではどのような変更が行われますか？ 該当するすべてのボックスに「x」を入力してください。 -->
- [ ] 不具合の修正
- [ ] 新しい機能の追加
- [x] 改善・リファクタリング（機能は追加されないが、動作やコードを改善する破壊的でない変更）

## チェックリスト:
<!-- 以下のすべての点に目を通し、該当するすべてのボックスに「x」を入力してください。 -->
- [x] [開発資料](https://mango-garlic-eff.notion.site/KonomiTV-90f4b25555c14b9ba0cf5498e6feb1c3) と [データベース設計](https://mango-garlic-eff.notion.site/KonomiTV-544e02334c89420fa24804ec70f46b6d) は読みましたか？
  - もともと自分用のメモですが、このプロジェクトの開発方針や設計などが記載されています。開発時の参考にしてください。
- [x] Git のコミットメッセージは開発資料に記載のフォーマットになっていますか？（重要）
  - このプロジェクト上のコミットメッセージは、基本的に全てこのフォーマットに従って記述されています（文字数は問いません）。
  - 正しいフォーマットになっていない場合、force push で必ずコミットメッセージを変更してから送信してください。
- [x] このプロジェクトのコーディング規約に従ったコードになっていますか？
  - コーディング規約は開発資料に記載されています。
  - そもそもコーディング規約と言えるほど大層なものではありませんが、一度目を通しておいてください。
- [x] プルリクエストは master ブランチに送信されていますか？
  - release ブランチはリリースした時にしか更新されません。必ず master ブランチに送信してください。

## 説明
QSVEnc/NVEnc/VCEEnc/rkmppencに追加された可変解像度対応をKonomiTVでも使用するようにし、既存の制限を解除します。

正直NHKのマスター更新で不要になった可能性大ですが…

## 動機とコンテキスト
簡易的ですが下記バージョンで可変解像度対応を追加しました。解像度が変わっても自動的にリサイズを追加して最初の出力解像度を保つような実装をしています。

- [QSVEnc 8.26](https://github.com/rigaya/QSVEnc/releases/tag/8.26)
- [NVEnc 9.31](https://github.com/rigaya/NVEnc/releases/tag/9.31)
- [VCEEnc 9.12](https://github.com/rigaya/VCEEnc/releases/tag/9.12)
- [rkmppenc 0.19](https://github.com/rigaya/rkmppenc/releases/tag/0.19)

`--adapt-resolution`で対応する最大入力解像度の指定が必要な簡易的な実装ですので、その指定を追加しています。4K解像度(BS4K)では3840x2160、それ以外では1920x1080を指定しています。

基本的には録画再生で動作検証しています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - ライブ配信・録画時の映像解像度変更に対応しました。
  - 4K映像には最大4K、その他の映像には最大フルHDの解像度が自動適用されます。
  - 解像度変更時も、エンコード処理がより安定して継続されます。

- **サムネイル・解析**
  - 映像ストリームの変化を検知し、サムネイル生成や解析時の注意情報として活用できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->