### PR TITLE
Fix: [server][KonomiTV-Service.py] SID 取得時のドメイン環境判定を追加

### DIFF
--- a/server/KonomiTV-Service.py
+++ b/server/KonomiTV-Service.py
@@ -270,12 +270,16 @@ def install(
         # コンピューター名とユーザーアカウント名から SID を取得
         if '\\' not in account_name or account_name.startswith('.\\'):
             computer_name = os.environ['COMPUTERNAME']
+            domain_name = os.environ['USERDOMAIN']
             if not computer_name:
                 computer_name: str = win32api.GetComputerName()
                 if not computer_name:
                     print('Error: Cannot determine computer name.')
                     return
-            account_name = computer_name + '\\' + account_name.lstrip('.\\')
+            if domain_name is None or computer_name == domain_name:
+                account_name = computer_name + '\\' + account_name.lstrip('.\\')
+            else:
+                account_name = domain_name + '\\' + account_name.lstrip('.\\')
         account_sid = win32security.LookupAccountName(None, account_name)[0]
 
         # ユーザーアカウントに SeServiceLogonRight 権限を付与

--- a/server/KonomiTV-Service.py
+++ b/server/KonomiTV-Service.py
@@ -269,14 +269,14 @@ def install(
 
         # コンピューター名とユーザーアカウント名から SID を取得
         if '\\' not in account_name or account_name.startswith('.\\'):
-            computer_name = os.environ['COMPUTERNAME']
-            domain_name = os.environ['USERDOMAIN']
+            computer_name = os.environ.get('COMPUTERNAME', '')
+            domain_name = os.environ.get('USERDOMAIN', '')
             if not computer_name:
                 computer_name: str = win32api.GetComputerName()
                 if not computer_name:
                     print('Error: Cannot determine computer name.')
                     return
-            if domain_name is None or computer_name == domain_name:
+            if not domain_name or computer_name == domain_name:
                 account_name = computer_name + '\\' + account_name.lstrip('.\\')
             else:
                 account_name = domain_name + '\\' + account_name.lstrip('.\\')


### PR DESCRIPTION
## 変更の種類
<!-- このプルリクエストではどのような変更が行われますか？ 該当するすべてのボックスに「x」を入力してください。 -->
- [x] 不具合の修正
- [ ] 新しい機能の追加
- [ ] 改善・リファクタリング（機能は追加されないが、動作やコードを改善する破壊的でない変更）

## チェックリスト:
<!-- 以下のすべての点に目を通し、該当するすべてのボックスに「x」を入力してください。 -->
- [x] [開発資料](https://mango-garlic-eff.notion.site/KonomiTV-90f4b25555c14b9ba0cf5498e6feb1c3) と [データベース設計](https://mango-garlic-eff.notion.site/KonomiTV-544e02334c89420fa24804ec70f46b6d) は読みましたか？
  - もともと自分用のメモですが、このプロジェクトの開発方針や設計などが記載されています。開発時の参考にしてください。
- [x] Git のコミットメッセージは開発資料に記載のフォーマットになっていますか？（重要）
  - このプロジェクト上のコミットメッセージは、基本的に全てこのフォーマットに従って記述されています（文字数は問いません）。
  - 正しいフォーマットになっていない場合、force push で必ずコミットメッセージを変更してから送信してください。
- [x] このプロジェクトのコーディング規約に従ったコードになっていますか？
  - コーディング規約は開発資料に記載されています。
  - そもそもコーディング規約と言えるほど大層なものではありませんが、一度目を通しておいてください。
- [x] プルリクエストは master ブランチに送信されていますか？
  - release ブランチはリリースした時にしか更新されません。必ず master ブランチに送信してください。

## 説明
<!-- このプルリクエストでの変更点を詳しく説明してください。 -->
インストールの際、
  - コンピューター名またはドメイン名を指定しない（デフォルト）場合:
    - コンピューター名とドメイン名が同一であればワークグループ環境と推定
      - "コンピューター名\\ユーザー名"
    - コンピューター名とドメイン名が異なれば、ドメイン環境と推定 - "ドメイン名\\ユーザー名"
  -  username が"コンピューター名\\ユーザー名"など、'\\'を含む場合:
    - 素通し

## 動機とコンテキスト
<!-- この変更はなぜ必要ですか？どのような問題が解決されますか？ -->
Server: Windows 11 (Samba AD 環境下の PC)
　登録時に"ユーザー名" だけを抽出し、コンピューター名を連結しているため、自動取得されたユーザー名と同名のローカルコンピューターのユーザーに設定されます。
　手元のワークグループ（=一般のローカルコンピューター）環境では、os.environ['USERDOMAIN'] は ['COMPUTERNAME']と同一であることを確認しています。
　この変更で、ローカル環境でのインストールに支障なく、おひとり様AD環境でもインストールを完走することが期待できます。（但し、非サポート環境。）
<!-- この変更で未解決の Issue が修正される場合は、ここにリンクを貼ってください。 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * ドメイン指定のないアカウントへの権限設定を改善しました。
  * 環境変数が未設定または空の場合でも、コンピューター名を使用して正しく権限を設定できるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->