### PR TITLE
Update: [Server] SID 取得時のドメイン環境判定を追加

### DIFF
--- a/installer/Installer.py
+++ b/installer/Installer.py
@@ -1020,11 +1020,11 @@ def Installer(version: str) -> None:
                 stderr = subprocess.DEVNULL,  # 標準エラー出力を表示しない
             )
 
-            # "プライベート" と "パブリック" で有効な受信規則を追加
+            # すべてのプロファイルで有効な受信規則を追加
             subprocess.run(
                 args = [
                     'netsh', 'advfirewall', 'firewall', 'add', 'rule', 'name=KonomiTV Service', 'description=KonomiTV Windows Service.',
-                    'profile=private,public', 'enable=yes', 'action=allow', 'dir=in', 'protocol=TCP',
+                    'profile=any', 'enable=yes', 'action=allow', 'dir=in', 'protocol=TCP',
                     f'program={install_path / "server/thirdparty/Akebi/akebi-https-server.exe"}',
                 ],
                 stdout = subprocess.DEVNULL,  # 標準出力を表示しない
@@ -1040,46 +1040,46 @@ def Installer(version: str) -> None:
         venv_python_executable_path = install_path / 'server/.venv/Scripts/python.exe'
 
         # 現在ログオン中のユーザー名を取得
-        ## PowerShell の [Environment]::UserName を使う
+        ## PowerShell の [Environment]::UserDomainName と [Environment]::UserName を使う
         current_user_name_default = subprocess.run(
-            args = ['powershell', '-Command', '[Environment]::UserName'],
+            args = ['powershell', '-Command', r'"$([Environment]::UserDomainName)\$([Environment]::UserName)"'],
             stdout = subprocess.PIPE,  # 標準出力をキャプチャする
             stderr = subprocess.DEVNULL,  # 標準エラー出力を表示しない
             text = True,  # 出力をテキストとして取得する
         ).stdout.strip()
 
-        table_08 = CreateTable()
-        table_08.add_column('08. KonomiTV の Windows サービスの実行ユーザー名を入力してください。')
-        table_08.add_row('KonomiTV の Windows サービスを一般ユーザーの権限で起動するために利用します。')
-        table_08.add_row('ほかのユーザー権限で実行したい場合は、そのユーザー名を入力してください。')
-        table_08.add_row(f'Enter キーを押すと、現在ログオン中のユーザー ({current_user_name_default}) が利用されます。')
-        print(Padding(table_08, (0, 2, 0, 2)))
-
-        # ユーザー名を入力
-        current_user_name: str = CustomPrompt.ask('KonomiTV の Windows サービスの実行ユーザー名', default=current_user_name_default)
-
-        table_09 = CreateTable()
-        table_09.add_column(f'09. ユーザー ({current_user_name}) のパスワードを入力してください。')
-        table_09.add_row('KonomiTV の Windows サービスを一般ユーザーの権限で起動するために利用します。')
-        table_09.add_row('入力されたパスワードがそれ以外の用途に利用されることはありません。')
-        table_09.add_row('間違ったパスワードを入力すると、KonomiTV が起動できなくなります。')
-        table_09.add_row('Enter キーを押す前に、正しいパスワードかどうか今一度確認してください。')
-        table_09.add_row('なお、PIN などのほかの認証方法には対応していません。')
-        table_09.add_row(CreateRule())
-        table_09.add_row('ログオン中のユーザーにパスワードを設定していない場合は、簡単なものでいいので')
-        table_09.add_row('何かパスワードを設定してから、その設定したパスワードを入力してください。')
-        table_09.add_row('なお、パスワードの設定後にインストーラーを起動し直す必要はありません。')
-        table_09.add_row(CreateRule())
-        table_09.add_row('ごく稀に、正しいパスワードを指定したのにログオンできない場合があります。')
-        table_09.add_row('その場合は、一度インストーラーを Ctrl+C で中断し、インストーラーの')
-        table_09.add_row('実行ファイルを Shift + 右クリック → [別のユーザーとして実行] から、')
-        table_09.add_row('ログオン中のユーザーとパスワードを指定して再度実行してみてください。')
-        print(Padding(table_09, (1, 2, 1, 2)))
-
-        # ユーザーのパスワードを取得
         while True:
 
-            # 入力プロンプト (サービスのインストールに失敗し続ける限り何度でも表示される)
+            table_08 = CreateTable()
+            table_08.add_column('08. KonomiTV の Windows サービスの実行ユーザー名を入力してください。')
+            table_08.add_row('KonomiTV の Windows サービスを一般ユーザーの権限で起動するために利用します。')
+            table_08.add_row('ほかのユーザー権限で実行したい場合は、そのユーザー名を入力してください。')
+            table_08.add_row(f'Enter キーを押すと、現在ログオン中のユーザー ({current_user_name_default}) が利用されます。')
+            print(Padding(table_08, (0, 2, 0, 2)))
+
+            # ユーザー名を入力 (サービスのインストールに失敗し続ける限り何度でも表示される)
+            current_user_name: str = CustomPrompt.ask('KonomiTV の Windows サービスの実行ユーザー名', default=current_user_name_default)
+
+            table_09 = CreateTable()
+            table_09.add_column(f'09. ユーザー ({current_user_name}) のパスワードを入力してください。')
+            table_09.add_row('KonomiTV の Windows サービスを一般ユーザーの権限で起動するために利用します。')
+            table_09.add_row('入力されたパスワードがそれ以外の用途に利用されることはありません。')
+            table_09.add_row('間違ったパスワードを入力すると、KonomiTV が起動できなくなります。')
+            table_09.add_row('Enter キーを押す前に、正しいパスワードかどうか今一度確認してください。')
+            table_09.add_row('なお、PIN などのほかの認証方法には対応していません。')
+            table_09.add_row(CreateRule())
+            table_09.add_row('ログオン中のユーザーにパスワードを設定していない場合は、簡単なものでいいので')
+            table_09.add_row('何かパスワードを設定してから、その設定したパスワードを入力してください。')
+            table_09.add_row('なお、パスワードの設定後にインストーラーを起動し直す必要はありません。')
+            table_09.add_row(CreateRule())
+            table_09.add_row('ごく稀に、正しいパスワードを指定したのにログオンできない場合があります。')
+            table_09.add_row('その場合は、一度インストーラーを Ctrl+C で中断し、インストーラーの')
+            table_09.add_row('実行ファイルを Shift + 右クリック → [別のユーザーとして実行] から、')
+            table_09.add_row('ログオン中のユーザーとパスワードを指定して再度実行してみてください。')
+            print(Padding(table_09, (1, 2, 1, 2)))
+
+            # ユーザーのパスワードを取得
+            # 入力プロンプト
             ## バリデーションのしようがないので、バリデーションは行わない
             current_user_password = CustomPrompt.ask(f'ログオン中のユーザー ({current_user_name}) のパスワード')
 
@@ -1103,12 +1103,21 @@ def Installer(version: str) -> None:
                     stderr = subprocess.DEVNULL,  # 標準エラー出力を表示しない
                     text = True,  # 出力をテキストとして取得する
                 )
+            if 'Error: ' in service_install_result.stdout:
+                print(Padding(
+                    '[red]Windows サービスのインストールに失敗しました。\n'\
+                    '入力されたユーザーが存在しないか、コンピューター名または\n'\
+                    'ドメイン名が間違っている可能性があります。'\
+                , (1, 2, 0, 2)))
+                print(Padding('[red]エラーログ:\n' + service_install_result.stdout.strip(), (1, 2, 1, 2)))
+                continue
+
             if 'Error installing service' in service_install_result.stdout:
-                print(Padding(str(
-                    '[red]Windows サービスのインストールに失敗しました。\n'
-                    '入力されたログオン中ユーザーのパスワードが間違っているか、\n'
-                    'すでに KonomiTV がインストールされている可能性があります。',
-                ), (1, 2, 0, 2)))
+                print(Padding(
+                    '[red]Windows サービスのインストールに失敗しました。\n'\
+                    '入力されたログオン中ユーザーのパスワードが間違っているか、\n'\
+                    'すでに KonomiTV がインストールされている可能性があります。'\
+                , (1, 2, 0, 2)))
                 print(Padding('[red]エラーログ:\n' + service_install_result.stdout.strip(), (1, 2, 1, 2)))
                 continue
 
@@ -1125,11 +1134,11 @@ def Installer(version: str) -> None:
                     text = True,  # 出力をテキストとして取得する
                 )
             if 'Error starting service' in service_start_result.stdout:
-                print(Padding(str(
-                    '[red]Windows サービスの起動に失敗しました。\n'
-                    '入力されたログオン中ユーザーのパスワードが間違っているか、\n'
-                    'すでに KonomiTV がインストールされている可能性があります。',
-                ), (1, 2, 0, 2)))
+                print(Padding(
+                    '[red]Windows サービスの起動に失敗しました。\n'\
+                    '入力されたログオン中ユーザーのパスワードが間違っているか、\n'\
+                    'すでに KonomiTV がインストールされている可能性があります。'\
+                , (1, 2, 0, 2)))
                 print(Padding('[red]エラーログ:\n' + service_start_result.stdout.strip(), (1, 2, 1, 2)))
                 continue
 

--- a/server/KonomiTV-Service.py
+++ b/server/KonomiTV-Service.py
@@ -341,7 +341,8 @@ def install(
 
                     # ドメイン名を取得してドメインコントローラーを探す
                     joined_domain_name, _ = win32net.NetGetJoinInformation()
-                    domain_controller_name = win32net.NetGetDCName(None, joined_domain_name)
+                    domain_controller_info = win32security.DsGetDcName(None, joined_domain_name, None, None, 0)
+                    domain_controller_name = domain_controller_info['DomainControllerName']
 
                     # ドメインコントローラーに問い合わせする
                     ## 見つかればドメイン所属

--- a/server/KonomiTV-Service.py
+++ b/server/KonomiTV-Service.py
@@ -269,9 +269,7 @@ def install(
             str: Windows SAM アカウント名 (computerName\\accountName)
         """
 
-        # すでに完全修飾（DOMAIN\user）されているが、.\\ で始まらない場合はそのまま返す
-        if '\\' in account_name and not account_name.startswith('.\\'):
-            return account_name
+        sid_type_user = 1
 
         # コンピュータ名の取得
         computer_name = os.environ.get('COMPUTERNAME', '')
@@ -280,6 +278,40 @@ def install(
             if not computer_name:
                 print('Error: Cannot determine computer name.')
                 sys.exit(1)
+
+        # すでに完全修飾（DOMAIN\user）されているが、.\\ で始まらない場合はそのまま返す
+        if '\\' in account_name and not account_name.startswith('.\\'):
+            # ドメイン（またはコンピュータ名）とユーザー名に分解
+            input_domain, input_user = account_name.split('\\', 1)
+
+            input_domain = '.' if (input_domain.upper() == computer_name.upper()) else input_domain
+
+            # 入力されたドメイン部分が "." の場合はローカル SAM に置き換える
+            search_server = None if input_domain == '.' else win32net.NetGetAnyDCName(None, input_domain)
+
+            try:
+                # 指定されたサーバーに対して直接照会
+                _, found_domain, account_type = win32security.LookupAccountName(search_server, input_user)
+
+                # ユーザーアカウントかチェック
+                if account_type != sid_type_user:
+                    print(f"Error: '{found_domain}\\{input_user}' is a group or non-user account. Only user accounts are allowed.")
+                    sys.exit(1)
+
+                print(f"Found validated user '{found_domain}\\{input_user}'.")
+                return found_domain + '\\' + input_user
+
+            except pywintypes.error as e:
+                # アカウントが見つからない場合
+                if e.winerror == 1332:
+                    print(f"Error: User '{account_name}' was not found.")
+                    sys.exit(1)
+                # サーバーが見つからないか、接続できない場合
+                elif e.winerror == 1722:
+                    print(f"Error: RPC server unavailable. Cannot contact domain '{input_domain}'.")
+                    sys.exit(1)
+                else:
+                    raise
 
         # ローカル指定の有無を確認しフラグ化する
         force_local = False
@@ -297,7 +329,7 @@ def install(
         # ローカルのSAMを検索し、アカウントが存在するか確認する
         ## ドメイン環境かつローカル指定がない場合はアカウントの種別を検証する
         try:
-            _, found_domain, _ = win32security.LookupAccountName(None, account_name)
+            _, found_domain, account_type = win32security.LookupAccountName(None, account_name)
 
             # ローカルアカウントか確認しフラグ化する
             is_hit_local = (found_domain.upper() == computer_name.upper())
@@ -306,19 +338,28 @@ def install(
             ## 同名のドメイン上のユーザーが実在するか確認する
             if is_domain_joined and not force_local and is_hit_local:
                 try:
+
                     # ドメイン名を取得してドメインコントローラーを探す
                     joined_domain_name, _ = win32net.NetGetJoinInformation()
                     domain_controller_name = win32net.NetGetDCName(None, joined_domain_name)
+
                     # ドメインコントローラーに問い合わせする
-                    ## 見つかればドメインユーザー
-                    _, domain_controller_domain, _ = win32security.LookupAccountName(domain_controller_name, account_name)
+                    ## 見つかればドメイン所属
+                    _, domain_controller_domain, account_type = win32security.LookupAccountName(domain_controller_name, account_name)
+
+                    # 取得したアカウントがユーザーか確認
+                    ## ユーザーではないときは終了
+                    if account_type != sid_type_user:
+                        print(f"Error: '{joined_domain_name}\\{account_name}' is a group or non-user account.\nOnly user accounts are allowed.")
+                        sys.exit(1)
+
+                    # 取得したユーザーの SAM アカウント名を返す
                     print(f'Found user \'{domain_controller_domain}\\{account_name}\' (Domain Priority).')
                     return domain_controller_domain + '\\' + account_name
+                except SystemExit:
+                    raise
                 except Exception:
-                    # ドメインコントローラーに接続できないかドメインに同名ユーザーがいない場合
-                    ## ローカルユーザーを採用する
-                    print(f'Found user \'{found_domain}\\{account_name}\' (Fallback to local account).')
-                    return found_domain + '\\' + account_name
+                    pass
 
             # ローカル指定にもかかわらずドメインユーザーが返ってきた場合
             ## 不正とみなす
@@ -327,7 +368,11 @@ def install(
                 print(f'Error: User \'{account_name}\' was not found on local computer.')
                 sys.exit(1)
 
-            # 期待するアカウントが取得できた場合
+            # 期待するアカウントが取得できた場合、取得したアカウントがユーザーか確認
+            ## ユーザーではない(=グループ)のときは終了
+            if account_type != sid_type_user:
+                print(f"Error: '{found_domain}\\{account_name}' is a group or non-user account. Only user accounts are allowed.")
+                sys.exit(1)
             print(f'Found user \'{found_domain}\\{account_name}\'.')
             return found_domain + '\\' + account_name
 
@@ -359,6 +404,7 @@ def install(
             # SID の取得に失敗したときは、ログメッセージを出力して例外を再スローする (終了)
             print(f'Error: Failed to look up SID for \'{account_name}\'.')
             raise
+
         # ユーザーアカウントに SeServiceLogonRight 権限を付与
         policy_handle = win32security.GetPolicyHandle('', win32security.POLICY_ALL_ACCESS)
         win32security.LsaAddAccountRights(policy_handle, account_sid, ('SeServiceLogonRight',))

--- a/server/KonomiTV-Service.py
+++ b/server/KonomiTV-Service.py
@@ -254,6 +254,37 @@ def install(
     username: str = typer.Option(..., help='Username under which KonomiTV service runs.'),
     password: str = typer.Option(..., help='Password of the user under which KonomiTV service runs.'),
 ):
+    def SamAccountNameHelper(account_name: str) -> str:
+        """
+        ユーザー名から SAM アカウント名を推定して返す
+        ローカルユーザーの場合、サービスのインストール後は自動的に.\\userNameへ変換される
+        Args:
+            account_name (str): accountName(str): Windows ユーザー名 (非修飾可)
+        Returns:
+            str: Windows SAM アカウント名 (computerName\\accountName)
+        """
+
+        # SAM アカウント名ではない場合またはローカル指定がある場合
+        if '\\' not in account_name or account_name.startswith('.\\'):
+            computer_name = os.environ.get('COMPUTERNAME', '')
+            domain_name = os.environ.get('USERDOMAIN', '')
+            if not computer_name:
+                computer_name: str = win32api.GetComputerName()
+                if not computer_name:
+                    # エラーメッセージ
+                    print('Error: Cannot determine computer name.')
+                    sys.exit(1)
+            if not domain_name:
+                domain_name = computer_name
+            # ローカル指定があるか、コンピューター名がドメイン名と同一の場合
+            ## ワークグループ (ローカルコンピューター)
+            if account_name.startswith('.\\') or computer_name == domain_name:
+                return computer_name + '\\' + (account_name[2:] if account_name.startswith('.\\') else account_name)
+            else:
+                return domain_name + '\\' + (account_name[2:] if account_name.startswith('.\\') else account_name)
+
+        return account_name
+
     def AddLogOnAsAServicePrivilege(account_name: str) -> None:
         """
         "サービスとしてログオン" (SeServiceLogonRight) 権限をユーザーアカウントに付与する
@@ -264,29 +295,32 @@ def install(
         ref: https://github.com/flathub/buildbot/blob/flathub/worker/buildbot_worker/scripts/windows_service.py#L480-L508
 
         Args:
-            account_name (str): accountName(str): Windows ユーザーアカウントの名前
+            account_name (str): accountName(str): Windows SAM アカウント名
         """
 
-        # コンピューター名とユーザーアカウント名から SID を取得
-        if '\\' not in account_name or account_name.startswith('.\\'):
-            computer_name = os.environ['COMPUTERNAME']
-            if not computer_name:
-                computer_name: str = win32api.GetComputerName()
-                if not computer_name:
-                    print('Error: Cannot determine computer name.')
-                    return
-            account_name = computer_name + '\\' + account_name.lstrip('.\\')
-        account_sid = win32security.LookupAccountName(None, account_name)[0]
-
+        # SAM アカウント名から SID を取得
+        try:
+            account_sid = win32security.LookupAccountName(None, account_name)[0]
+        except win32security.error:
+            # SID の取得に失敗したときは、ログメッセージを出力して例外を再スローする (終了)
+            print(f'Error: Failed to look up SID for \'{account_name}\'.')
+            raise
         # ユーザーアカウントに SeServiceLogonRight 権限を付与
         policy_handle = win32security.GetPolicyHandle('', win32security.POLICY_ALL_ACCESS)
         win32security.LsaAddAccountRights(policy_handle, account_sid, ('SeServiceLogonRight',))
         win32security.LsaClose(policy_handle)
 
+    # SAM アカウント名を取得
+    account_name = SamAccountNameHelper(username)
+    if not account_name or '\\' not in account_name:
+        # 取得できなかったときは終了する (念のため)
+        print('Error: Failed to parse SAM account name.')
+        return
+
     # 指定されたユーザーアカウントに "サービスとしてログオン" (SeServiceLogonRight) 権限を付与する
     ## "サービスとしてログオン" 権限が付与されていないと、ユーザー権限で Windows サービスを起動することができない
     ## 手動でサービス管理ツールから操作すると自動的に付与されるらしく、気づくのに時間が掛かった…
-    AddLogOnAsAServicePrivilege(username)
+    AddLogOnAsAServicePrivilege(account_name)
 
     # HandleCommandLine に直接引数を指定して、サービスのインストールを実行
     win32serviceutil.HandleCommandLine(
@@ -294,7 +328,7 @@ def install(
         # 「自動 (遅延開始)」(delayed) でインストールする
         ## 「自動」(auto) だと EDCB や Mirakurun のサービスが起動していない段階で実行されてしまい、EDCB または Mirakurun にアクセスできず起動に失敗する
         ## 「自動 (遅延開始)」だとシステム起動から2分ほど遅れて実行されるが、上記の問題があるため致し方ない
-        argv = [sys.argv[0], '--startup', 'delayed', '--username', f'.\\{username}', '--password', password, 'install'],
+        argv = [sys.argv[0], '--startup', 'delayed', '--username', account_name, '--password', password, 'install'],
     )
 
 @app.command(help='Uninstall KonomiTV service.')

--- a/server/KonomiTV-Service.py
+++ b/server/KonomiTV-Service.py
@@ -22,6 +22,8 @@ import servicemanager
 import typer
 import win32api
 import win32con
+import win32net
+import win32netcon
 import win32security
 import win32service
 import win32serviceutil
@@ -256,34 +258,86 @@ def install(
 ):
     def SamAccountNameHelper(account_name: str) -> str:
         """
-        ユーザー名から SAM アカウント名を推定して返す
+        ユーザー名から SAM アカウント名を推定する
+        ローカル指定がある、または推定した場合は、実在するか確認する
+        存在するか、SAM アカウント名が入力された場合、SAM アカウント名を返す
         ローカルユーザーの場合、サービスのインストール後は自動的に.\\userNameへ変換される
+
         Args:
-            account_name (str): accountName(str): Windows ユーザー名 (非修飾可)
+            account_name (str): Windows ユーザー名 (非修飾可)
         Returns:
             str: Windows SAM アカウント名 (computerName\\accountName)
         """
 
-        # SAM アカウント名ではない場合またはローカル指定がある場合
-        if '\\' not in account_name or account_name.startswith('.\\'):
-            computer_name = os.environ.get('COMPUTERNAME', '')
-            domain_name = os.environ.get('USERDOMAIN', '')
-            if not computer_name:
-                computer_name: str = win32api.GetComputerName()
-                if not computer_name:
-                    # エラーメッセージ
-                    print('Error: Cannot determine computer name.')
-                    sys.exit(1)
-            if not domain_name:
-                domain_name = computer_name
-            # ローカル指定があるか、コンピューター名がドメイン名と同一の場合
-            ## ワークグループ (ローカルコンピューター)
-            if account_name.startswith('.\\') or computer_name == domain_name:
-                return computer_name + '\\' + (account_name[2:] if account_name.startswith('.\\') else account_name)
-            else:
-                return domain_name + '\\' + (account_name[2:] if account_name.startswith('.\\') else account_name)
+        # すでに完全修飾（DOMAIN\user）されているが、.\\ で始まらない場合はそのまま返す
+        if '\\' in account_name and not account_name.startswith('.\\'):
+            return account_name
 
-        return account_name
+        # コンピュータ名の取得
+        computer_name = os.environ.get('COMPUTERNAME', '')
+        if not computer_name:
+            computer_name = win32api.GetComputerName()
+            if not computer_name:
+                print('Error: Cannot determine computer name.')
+                sys.exit(1)
+
+        # ローカル指定の有無を確認しフラグ化する
+        force_local = False
+        if account_name.startswith('.\\'):
+            account_name = account_name[2:]
+            force_local = True
+
+        # 端末のドメイン参加状態を取得する
+        try:
+            _, join_status = win32net.NetGetJoinInformation()
+            is_domain_joined = (join_status == win32netcon.NetSetupDomainName)
+        except Exception:
+            is_domain_joined = False
+
+        # ローカルのSAMを検索し、アカウントが存在するか確認する
+        ## ドメイン環境かつローカル指定がない場合はアカウントの種別を検証する
+        try:
+            _, found_domain, _ = win32security.LookupAccountName(None, account_name)
+
+            # ローカルアカウントか確認しフラグ化する
+            is_hit_local = (found_domain.upper() == computer_name.upper())
+
+            # ドメイン環境下でローカルユーザーがマッチしたとき
+            ## 同名のドメイン上のユーザーが実在するか確認する
+            if is_domain_joined and not force_local and is_hit_local:
+                try:
+                    # ドメイン名を取得してドメインコントローラーを探す
+                    joined_domain_name, _ = win32net.NetGetJoinInformation()
+                    domain_controller_name = win32net.NetGetDCName(None, joined_domain_name)
+                    # ドメインコントローラーに問い合わせする
+                    ## 見つかればドメインユーザー
+                    _, domain_controller_domain, _ = win32security.LookupAccountName(domain_controller_name, account_name)
+                    print(f'Found user \'{domain_controller_domain}\\{account_name}\' (Domain Priority).')
+                    return domain_controller_domain + '\\' + account_name
+                except Exception:
+                    # ドメインコントローラーに接続できないかドメインに同名ユーザーがいない場合
+                    ## ローカルユーザーを採用する
+                    print(f'Found user \'{found_domain}\\{account_name}\' (Fallback to local account).')
+                    return found_domain + '\\' + account_name
+
+            # ローカル指定にもかかわらずドメインユーザーが返ってきた場合
+            ## 不正とみなす
+            ## ドメインユーザーとしてローカルに居る(既知の?)ユーザーが対象
+            if force_local and not is_hit_local:
+                print(f'Error: User \'{account_name}\' was not found on local computer.')
+                sys.exit(1)
+
+            # 期待するアカウントが取得できた場合
+            print(f'Found user \'{found_domain}\\{account_name}\'.')
+            return found_domain + '\\' + account_name
+
+        except pywintypes.error as e:
+            # アカウントが見つからない場合
+            if e.winerror == 1332:
+                print(f'Error: User \'{account_name}\' was not found.')
+                sys.exit(1)
+            else:
+                raise
 
     def AddLogOnAsAServicePrivilege(account_name: str) -> None:
         """


### PR DESCRIPTION
## 変更の種類
<!-- このプルリクエストではどのような変更が行われますか？ 該当するすべてのボックスに「x」を入力してください。 -->
- [x] 不具合の修正
- [ ] 新しい機能の追加
- [ ] 改善・リファクタリング（機能は追加されないが、動作やコードを改善する破壊的でない変更）

## チェックリスト:
<!-- 以下のすべての点に目を通し、該当するすべてのボックスに「x」を入力してください。 -->
- [x] [開発資料](https://mango-garlic-eff.notion.site/KonomiTV-90f4b25555c14b9ba0cf5498e6feb1c3) と [データベース設計](https://mango-garlic-eff.notion.site/KonomiTV-544e02334c89420fa24804ec70f46b6d) は読みましたか？
  - もともと自分用のメモですが、このプロジェクトの開発方針や設計などが記載されています。開発時の参考にしてください。
- [x] Git のコミットメッセージは開発資料に記載のフォーマットになっていますか？（重要）
  - このプロジェクト上のコミットメッセージは、基本的に全てこのフォーマットに従って記述されています（文字数は問いません）。
  - 正しいフォーマットになっていない場合、force push で必ずコミットメッセージを変更してから送信してください。
- [x] このプロジェクトのコーディング規約に従ったコードになっていますか？
  - コーディング規約は開発資料に記載されています。
  - そもそもコーディング規約と言えるほど大層なものではありませんが、一度目を通しておいてください。
- [x] プルリクエストは master ブランチに送信されていますか？
  - release ブランチはリリースした時にしか更新されません。必ず master ブランチに送信してください。

## 説明
<!-- このプルリクエストでの変更点を詳しく説明してください。 -->
Windows サービス インストールの際、
  - SAMアカウント名の処理を実施するヘルパーを追加
    - コンピューター名またはドメイン名を指定しない場合:
      - コンピューター名とドメイン名が同一であればワークグループ環境と推定
        - "コンピューター名\\ユーザー名" - コンピューター名とドメイン名が異なれば、ドメイン環境と推定
        - "ドメイン名\\ユーザー名"
    - username が"コンピューター名\\ユーザー名"など、'\\'を含む場合: 
      - 素通し(既に SAM アカウント名と推定)
    - アカウントが実在するか、SIDを取得して確認
      - ドメイン環境でローカルユーザーが返された場合はドメインコントローラーに照会
        - 同名のドメインユーザーがいる場合は、ドメインユーザーを返す
      - ユーザーアカウント以外（グループなど）の場合はエラーメッセージを出力する
  - SID の取得失敗と SAM アカウント名のパース失敗時のエラーメッセージを追加

インストーラーにおいて、
  - Windows Defender 受信規則の追加時、すべてのプロファイルを指定するよう変更
  - ユーザー名取得時に、コンピューター名を含めるように変更
  - KonomiTV-Service 内で失敗した際の、エラーメッセージを処理するよう変更
  - エラーからの再試行時、ユーザー名入力に戻るようループの開始位置を変更

## 動機とコンテキスト
<!-- この変更はなぜ必要ですか？どのような問題が解決されますか？ -->
<!-- この変更で未解決の Issue が修正される場合は、ここにリンクを貼ってください。 -->
  - ドメイン環境下の PC でインストーラーを実行すると、ローカルコンピューターのユーザーアカウントとして処理されるため、存在しないユーザーアカウントに対する SID の取得を試行し、サービスのインストールで失敗し、サービスの起動まで進み、エラーが発生します。
  - ループの開始点がパスワード入力プロンプトのため、別のユーザーを作成 or 指定したくても Ctrl+C で終了して最初からインストーラーを実行する必要があります。
  - インストーラーで取得するユーザーアカウント名を、コンピューター名を含む形式 (SAM アカウント名) に変更することで、(古い互換性のある)ドメイン環境やローカル上のユーザーアカウントでインストールが完走します。
    - 他方、UPN 形式 (user@domain) の環境下では、古い互換性が有効な場合を除き、**正常に処理されません**。
  - Windows Defender ルールを追加する際、ドメインも有効にするため、プロファイルを `any` に変更しています。
    - `profiles=domain,private,public` と同義
  - メッセージやプロンプトを厳密に解釈したユーザーが、ユーザー名のみを入力した場合は、PC がドメイン環境下かを推定し、SAM アカウント名での設定を試みます。(従来の入力方法との互換性維持)

### 検証環境
  * PDC
    * Samba 4.23.4 ( on AlmaLinux 10 VM)
    * Windows Server 2008 R2 相当 ( NetBIOS 名あり)
  * サーバー(ワークグループ)
    * OS: Windows 11 Pro
  * サーバー(ドメイン)
    * OS: Windows 11 Pro

  - ドメイン環境では、" Windows サービスを起動しています… "の後にエラーが発生します。
  - この変更により、ドメイン環境でのドメインユーザーとローカルユーザーの両方がインストール可能になります。
    - 検証環境のサーバーにおいて、いずれもインストールが完走したことを確認しています。
  - 別のユーザーを指定したとき、保存先フォルダのパス等を UNC 形式で指定している場合、環境によってはアクセスに失敗し、サービスが起動に失敗します。
    - 別のユーザーで当該パスへアクセスできる状態にすることで回避できます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 改善

* Windowsサービスのインストール時に、ドメインアカウントやローカルアカウントを適切に指定できるようになりました。
* 指定したアカウントの存在とユーザー種別を確認し、不正なアカウントを検出しやすくなりました。
* ユーザー名やパスワードを再入力して、サービスのインストールを再試行しやすくなりました。
* インストールやサービス起動に失敗した際のエラー表示を改善しました。
* Windowsファイアウォールの受信規則が、すべてのネットワークプロファイルで適用されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->