### PR TITLE
Add: [Server][Streams] 録画再生時に副音声トラックを選択できる機能を追加

### DIFF
--- a/server/app/streams/StreamEncodingOptions.py
+++ b/server/app/streams/StreamEncodingOptions.py
@@ -14,6 +14,7 @@ class StreamEncodingOptions:
     Args:
         is_hevc_10bit_enabled (bool): HEVC 10bit を要求するクライアント向けのストリームかどうか
         is_24fps_mode_enabled (bool): 24fps モードを適用するストリームかどうか
+        audio_track_index (int): 選択する音声トラックの 0 スタートのインデックス (録画のみ、ライブでは常に 0)
     """
 
     # HEVC 10bit を要求するクライアント向けのストリームかどうか
@@ -25,12 +26,19 @@ class StreamEncodingOptions:
     ## 1080p-60fps では 60fps 化を優先し、24fps モードの要求があってもここでは無効にする
     is_24fps_mode_enabled: bool = False
 
+    # 選択する音声トラックの 0 スタートのインデックス (録画のみ、ライブでは常に 0)
+    ## 0: 主音声 (デフォルト), 1: 副音声。指定したインデックスの音声トラックが録画データに存在しない場合
+    ## (録画マージン内でまだ副音声が始まっていない場合など)、セグメント単位で主音声にフォールバックする
+    ## — VideoEncodingTask.run() 側の処理であり、ここでは指定値を保持するだけ
+    audio_track_index: int = 0
+
     @classmethod
     def fromRequest(
         cls,
         quality: QUALITY_TYPES,
         is_hevc_10bit_requested: bool,
         is_24fps_mode_requested: bool,
+        audio_track_index_requested: int = 0,
     ) -> StreamEncodingOptions:
         """
         API で指定されたオプションから、実際に使うストリームオプションを作る
@@ -39,6 +47,7 @@ class StreamEncodingOptions:
             quality (QUALITY_TYPES): ベース画質
             is_hevc_10bit_requested (bool): クライアントが HEVC 10bit を要求しているかどうか
             is_24fps_mode_requested (bool): クライアントが 24fps モードを要求しているかどうか
+            audio_track_index_requested (int): クライアントが要求する音声トラックインデックス (0: 主音声, 1: 副音声)
 
         Returns:
             StreamEncodingOptions: 実際のストリーム生成に使うエンコードオプション
@@ -59,9 +68,14 @@ class StreamEncodingOptions:
             QUALITY[quality].is_60fps is False
         )
 
+        # 現状 ARIB 放送で意味を持つのは主音声 (0) と副音声 (1) のみ
+        ## 不正な値が渡された場合は安全側に倒して主音声にする
+        audio_track_index = audio_track_index_requested if audio_track_index_requested in (0, 1) else 0
+
         return cls(
             is_hevc_10bit_enabled = is_hevc_10bit_enabled,
             is_24fps_mode_enabled = is_24fps_mode_enabled,
+            audio_track_index = audio_track_index,
         )
 
     def buildSuffix(self) -> str:
@@ -81,6 +95,12 @@ class StreamEncodingOptions:
         # 24fps モードが有効なストリームだけ -24fps を付ける
         if self.is_24fps_mode_enabled is True:
             suffix += '-24fps'
+
+        # 音声トラック指定は他のオプションと独立した概念のため、既存の並び (10bit → 24fps) の
+        # 一番最後に付ける。主音声 (index 0) の場合は既存の URL 形式を一切変えないよう、
+        # 接尾辞自体を付けない
+        if self.audio_track_index != 0:
+            suffix += f'-audio{self.audio_track_index + 1}'
 
         return suffix
 
@@ -124,9 +144,16 @@ def SplitQualityAndEncodingOptions(quality: str) -> StreamQualityWithOptions | N
             encoding_options = StreamEncodingOptions(),
         )
 
-    # -10bit / -24fps は buildSuffix() と同じ順序でのみ受け付ける
+    # -10bit / -24fps / -audio2 は buildSuffix() と同じ順序でのみ受け付ける
     ## 末尾から剥がすことで、1080p-60fps-hevc のようにベース画質自体が -hevc を含むケースを安全に扱う
     base_quality = quality
+
+    # -audio2 は buildSuffix() で一番最後に付けているため、剥がすのも一番最初に行う
+    audio_track_index_requested = 0
+    if base_quality.endswith('-audio2') is True:
+        base_quality = base_quality[:-len('-audio2')]
+        audio_track_index_requested = 1
+
     is_24fps_mode_requested = False
     if base_quality.endswith('-24fps') is True:
         base_quality = base_quality[:-len('-24fps')]
@@ -147,6 +174,7 @@ def SplitQualityAndEncodingOptions(quality: str) -> StreamQualityWithOptions | N
         base_quality,
         is_hevc_10bit_requested,
         is_24fps_mode_requested,
+        audio_track_index_requested,
     )
     return StreamQualityWithOptions(
         quality = base_quality,

--- a/server/app/streams/VideoEncodingTask.py
+++ b/server/app/streams/VideoEncodingTask.py
@@ -21,12 +21,118 @@ from biim.mpeg2ts.parser import PESParser, SectionParser
 from biim.mpeg2ts.pat import PATSection
 from biim.mpeg2ts.pes import PES
 from biim.mpeg2ts.pmt import PMTSection
+from biim.mpeg2ts.section import Section
 
 from app import logging
 from app.config import Config
 from app.constants import LIBRARY_PATH, QUALITY, QUALITY_TYPES
 from app.schemas import KeyFrame
 from app.utils.TSKeyFrameSeeker import TSKeyFrameCollector
+
+
+def _BuildFilteredPMTPayload(pmt: PMTSection, exclude_pids: set[int]) -> bytes:
+    """
+    与えられた PMTSection から、exclude_pids に含まれる Elementary PID の
+    ストリームエントリを取り除いた、新しく妥当な PMT セクションのバイト列を再構築する
+
+    packetize_section() は Section の生バイト列 (__len__/__getitem__ 経由) を
+    そのまま切り出すだけで、PMTSection.entry (パース済みのリスト) の内容は
+    一切参照しない。そのため entry を直接編集しても出力には反映されず、
+    実際に送出される PMT のバイト列自体を正しい PSI 構文で組み立て直す必要がある。
+
+    これが必要な理由: 副音声選択で選ばれなかった方の AAC PID のパケットは
+    VideoEncodingTask.run() 側で既にドロップされているが、PMT 自体は元のまま
+    (音声ストリームが2本あると宣言したまま) 転送されていた。この不整合
+    (PMT は2本と宣言するが実際には1本しかデータが来ない) が、AVPlayer 側で
+    HLS セグメントの解決に極端に長い時間 (数分) がかかったり、最終的に無音に
+    なったりする原因だったと実機で確認された (ffprobe/ffplay など寛容な
+    パーサーでは問題が表面化しなかった)。
+
+    Args:
+        pmt (PMTSection): 元の (フィルタリング前の) PMTSection
+        exclude_pids (set[int]): ストリームエントリを除外する Elementary PID の集合
+
+    Returns:
+        bytes: exclude_pids のエントリを取り除き、CRC32 を再計算済みの新しい PMT セクションのバイト列
+    """
+
+    payload = pmt.payload
+
+    table_id = payload[0]
+    original_byte1 = payload[1]
+    table_id_extension = pmt.table_id_extension()
+    original_byte5 = payload[5]  # reserved + version_number + current_next_indicator, そのまま維持
+    section_number = pmt.section_number()
+    last_section_number = pmt.last_section_number()
+    pcr_pid = pmt.PCR_PID
+    original_pcr_pid_high_byte = payload[Section.EXTENDED_HEADER_SIZE + 0]
+
+    program_info_length = (
+        (payload[Section.EXTENDED_HEADER_SIZE + 2] & 0x0F) << 8
+    ) | payload[Section.EXTENDED_HEADER_SIZE + 3]
+    original_program_info_length_high_byte = payload[Section.EXTENDED_HEADER_SIZE + 2]
+    program_info_start = Section.EXTENDED_HEADER_SIZE + 4
+    program_info_bytes = bytes(payload[program_info_start: program_info_start + program_info_length])
+
+    # 除外対象でないストリームだけを残してストリームループ部分を再構築する
+    stream_loop = bytearray()
+    for stream_type, elementary_pid, descriptors in pmt.entry:
+        if elementary_pid in exclude_pids:
+            continue
+        descriptors_bytes = bytearray()
+        for descriptor_tag, descriptor_data in descriptors:
+            descriptors_bytes += bytes([descriptor_tag, len(descriptor_data)])
+            descriptors_bytes += bytes(descriptor_data)
+        es_info_length = len(descriptors_bytes)
+        stream_loop += bytes([
+            stream_type,
+            0xE0 | ((elementary_pid >> 8) & 0x1F),
+            elementary_pid & 0xFF,
+            0xF0 | ((es_info_length >> 8) & 0x0F),
+            es_info_length & 0xFF,
+        ])
+        stream_loop += descriptors_bytes
+
+    new_section_length = (
+        2 +  # table_id_extension
+        1 +  # version_number/current_next_indicator
+        1 +  # section_number
+        1 +  # last_section_number
+        2 +  # PCR_PID
+        2 +  # program_info_length
+        program_info_length +
+        len(stream_loop) +
+        Section.CRC_SIZE
+    )
+
+    header = bytes([
+        table_id,
+        (original_byte1 & 0xF0) | ((new_section_length >> 8) & 0x0F),
+        new_section_length & 0xFF,
+        (table_id_extension >> 8) & 0xFF,
+        table_id_extension & 0xFF,
+        original_byte5,
+        section_number,
+        last_section_number,
+        (original_pcr_pid_high_byte & 0xE0) | ((pcr_pid >> 8) & 0x1F),
+        pcr_pid & 0xFF,
+        (original_program_info_length_high_byte & 0xF0) | ((program_info_length >> 8) & 0x0F),
+        program_info_length & 0xFF,
+    ])
+
+    body_without_crc = header + program_info_bytes + bytes(stream_loop)
+
+    # 既存の Section.CRC32() をそのまま流用する (CRC アルゴリズムを
+    # 独自に再実装して転記ミスのリスクを負わないため)
+    crc = Section(body_without_crc).CRC32()
+    crc_bytes = bytes([
+        (crc >> 24) & 0xFF,
+        (crc >> 16) & 0xFF,
+        (crc >> 8) & 0xFF,
+        crc & 0xFF,
+    ])
+
+    return body_without_crc + crc_bytes
 
 
 if TYPE_CHECKING:
@@ -613,6 +719,10 @@ class VideoEncodingTask:
                 video_cc: int = 0
                 audio_pid: int | None = None
                 audio_cc: int = 0
+                # 見つかった全ての AAC (副音声を含む) の PID を PMT に現れた順に保持する
+                # 録画マージン内 (実際の番組が始まる前) では副音声がまだ存在しないことがあるため、
+                # 要求されたインデックスが見つからない場合は主音声 (index 0) にフォールバックする
+                audio_pids: list[int] = []
 
                 # 録画ファイルが MPEG-4 形式の場合、psisimux で MPEG-TS に変換し、
                 # TS ファイル入力の代わりに psisimux からの出力を tsreadex への入力として渡す
@@ -811,8 +921,15 @@ class VideoEncodingTask:
                     '-a', '13',
                     # 副音声ストリームが常に存在する状態にする
                     ## +1: ストリームが存在しない場合、無音の AAC ストリームが出力される
+                    ## +2: ストリームが存在しない場合、主音声をコピーする
                     ## +4: 音声がモノラルであればステレオにする
-                    '-b', '5',
+                    ## +2 は「副音声を選択する手段がないのに主音声分のデータ量が倍になる」ことを理由に
+                    ## 上流で削除されたが、本パッチでは選択されなかった方の音声パケットをエンコーダーに
+                    ## 渡す前に破棄するため (このファイル内、後述)、+2 を有効にしてもクライアントへの
+                    ## 転送量は変わらない。むしろ +2 を有効にすることで、副音声がまだ存在しない区間
+                    ## (録画マージンなど) でクライアントが副音声を要求した際に、無音ではなく主音声へ
+                    ## フォールバックできるようになる
+                    '-b', '7',
                     # 字幕ストリームが常に存在する状態にする
                     ## +1: ストリームが存在しない場合、PMT の項目が補われて出力される
                     ## +4: 実際の字幕データが現れない場合に5秒ごとに非表示の適当なデータを挿入する
@@ -1132,7 +1249,6 @@ class VideoEncodingTask:
                         for pmt in pmt_parser:
                             if pmt.CRC32() != 0:
                                 continue
-                            latest_pmt = pmt
 
                             # ストリームの PID を取得
                             for stream_type, elementary_pid, _ in pmt:
@@ -1149,11 +1265,49 @@ class VideoEncodingTask:
                                         video_parser = PESParser(H265PES)
                                         logging.debug(f'{self.video_stream.log_prefix} H.265 PID: 0x{elementary_pid:04x}')
                                 elif stream_type == 0x0F:  # AAC
-                                    if audio_pid is None:
-                                        audio_pid = elementary_pid
-                                        logging.debug(f'{self.video_stream.log_prefix} AAC PID: 0x{elementary_pid:04x}')
+                                    if elementary_pid not in audio_pids:
+                                        audio_pids.append(elementary_pid)
+                                        logging.debug(
+                                            f'{self.video_stream.log_prefix} AAC PID: 0x{elementary_pid:04x} '
+                                            f'(track index {len(audio_pids) - 1})'
+                                        )
+                            # 収集した音声 PID から、要求されたトラックインデックスを選択する
+                            # 要求されたインデックスが見つからない場合 (録画マージン内でまだ副音声が
+                            # 存在しない場合など) は、主音声 (index 0) にフォールバックする
+                            # ここで audio_pid を None のままにしないことが重要:
+                            # 後段の "video_pid is None or audio_pid is None" チェックが
+                            # リトライ処理につながっており、要求されたトラックが一時的に存在しないだけの
+                            # ケースでリトライを繰り返しても解決しないため
+                            if audio_pid is None and len(audio_pids) > 0:
+                                requested_index = self.video_stream.encoding_options.audio_track_index
+                                if requested_index < len(audio_pids):
+                                    audio_pid = audio_pids[requested_index]
+                                else:
+                                    # tsreadex は基本的に主音声・副音声の両方の PID を常に出力する
+                                    # ("-a" "-b" オプションの +1 ビット) ため、この分岐に実際に
+                                    # 到達することはほぼ無いはずだが、tsreadex 自体のソースコードや
+                                    # 全ての挙動を精査できているわけではないため、念のため残してある
+                                    audio_pid = audio_pids[0]
+                                    logging.debug(
+                                        f'{self.video_stream.log_prefix} Requested audio track index '
+                                        f'{requested_index} not yet present (only {len(audio_pids)} audio '
+                                        f'track(s) found in this segment) — falling back to track index 0.'
+                                    )
+
+                            # 選択されなかった方の AAC PID は、PMT 自体からもストリーム
+                            # エントリを取り除く。パケット単位では既にドロップ済みだが
+                            # (audio_pids に含まれ audio_pid と一致しないもの)、PMT が
+                            # 「音声ストリームが2本ある」と宣言したまま送出されると、
+                            # 実際には片方にデータが来ないという不整合が生じてしまう
+                            excluded_audio_pids = {p for p in audio_pids if p != audio_pid}
+                            if excluded_audio_pids:
+                                pmt_to_emit = PMTSection(_BuildFilteredPMTPayload(pmt, excluded_audio_pids))
+                            else:
+                                pmt_to_emit = pmt
+                            latest_pmt = pmt_to_emit
+
                             # PMT を再構築して candidate に追加
-                            for packet in packetize_section(pmt, False, False, cast(int, pmt_pid), 0, pmt_cc):
+                            for packet in packetize_section(pmt_to_emit, False, False, cast(int, pmt_pid), 0, pmt_cc):
                                 encoded_segment += packet
                                 pmt_cc = (pmt_cc + 1) & 0x0F
 
@@ -1283,6 +1437,14 @@ class VideoEncodingTask:
                             for packet in packetize_pes(audio, False, False, cast(int, audio_pid), 0, audio_cc):
                                 encoded_segment += packet
                                 audio_cc = (audio_cc + 1) & 0x0F
+
+                    # 選択されなかった方の音声 PID (主音声/副音声のうち非選択側) のパケットは、
+                    # そのまま通すとエンコーダーへの入力に2系統目の音声として紛れ込んでしまい、
+                    # 要求したトラックとは無関係に両方の音声トラックが最終的な出力セグメントに
+                    # 含まれてしまう (実際に確認済み)。既知の (選択されなかった) AAC PID の
+                    # パケットはここで明示的に破棄する
+                    elif pid in audio_pids:
+                        pass
 
                     # その他のパケット
                     else:


### PR DESCRIPTION
## 変更の種類
<!-- このプルリクエストではどのような変更が行われますか？ 該当するすべてのボックスに「x」を入力してください。 -->
- [ ] 不具合の修正
- [x] 新しい機能の追加
- [ ] 改善・リファクタリング（機能は追加されないが、動作やコードを改善する破壊的でない変更）

## チェックリスト:
<!-- 以下のすべての点に目を通し、該当するすべてのボックスに「x」を入力してください。 -->
- [x] [開発資料](https://mango-garlic-eff.notion.site/KonomiTV-90f4b25555c14b9ba0cf5498e6feb1c3) と [データベース設計](https://mango-garlic-eff.notion.site/KonomiTV-544e02334c89420fa24804ec70f46b6d) は読みましたか？
- [x] Git のコミットメッセージは開発資料に記載のフォーマットになっていますか？（重要）
- [x] このプロジェクトのコーディング規約に従ったコードになっていますか？
- [x] プルリクエストは master ブランチに送信されていますか？

## 説明
<!-- このプルリクエストでの変更点を詳しく説明してください。 -->

録画再生時に副音声トラックを選択できるようにしました。

* API の quality パラメータに副音声を指定する -audio2 を追加しました
  （例: /api/streams/video/{video_id}/{quality}-audio2/playlist）。
  quality に -audio2 を付けない場合の挙動は変更していません。
* HLS セグメントのエンコード中に PMT に記載されている AAC ストリームを確認し、
  指定されたインデックスの音声ストリームを選択するようにしました。
* 指定されたインデックスの音声ストリームがまだ存在しない場合（録画マージン内など）は、
  主音声にフォールバックするようにしました。
* 選択されなかった音声ストリームのパケットがエンコーダに到達しないようにし、
  PMT も実際に含まれる音声ストリームのみを宣言するように再構築しています。
  なお、この対応の過程で、副音声を要求していない通常のリクエストでも副音声データが
  セグメントに含まれてしまっていたため、あわせて修正しています。

クライアント側の UI は実装していません。副音声の有無を事前に判定する仕組みもないため、
今のところ音声トラックの選択はクライアント側で任意にリクエストする形になります。

## 動機とコンテキスト
<!-- この変更はなぜ必要ですか？どのような問題が解決されますか？ -->
<!-- この変更で未解決の Issue が修正される場合は、ここにリンクを貼ってください。 -->

KonomiTV をバックエンドとして利用するクライアントアプリを開発しており、その中で
音声切替機能を実装したいと考えていました。ライブ視聴では既に音声切替に対応して
いますが、録画再生では対応していないことに気づき、今回の対応に至りました。

調べたところ、エンコーダ（NVEncC）側は元々2音声トラックの出力に対応していました。

    --audio-stream 1?:stereo --audio-stream 2?:stereo

しかし、クライアントからどちらの音声トラックを再生したいか指定する手段が存在せず、
副音声を選択する仕組みがサーバー側にもクライアント側にも実装されていませんでした。

また、録画再生に使われている Media Playlist にはネゴシエーションの仕組みがなく、
クライアント側で音声トラックを選択可能にするには、HLS の alternate rendition
(#EXT-X-MEDIA) の仕組み上、既存のセグメントとは別に音声トラックごとの実データを
別途用意する必要があり、実装コストが大きいことも分かりました。

これらを踏まえ、quality パラメータへの -audio2 という形でクライアントの意図を
サーバーに伝え、サーバー側で音声トラックを選択する方式を採用しました。

### 変更したファイル

* `server/app/streams/StreamEncodingOptions.py`
  * `audio_track_index` フィールドを追加。
  * `fromRequest()` で `audio_track_index_requested` を受け取り、検証するように変更。
  * `buildSuffix()` で副音声選択時に `-audio2` を付与するように変更。
  * `SplitQualityAndEncodingOptions()` で quality から `-audio2` を解析するように変更。

* `server/app/streams/VideoEncodingTask.py`
  * PMT から指定した PID のエントリを除いて再構築する `_BuildFilteredPMTPayload()` を追加。
  * 見つかった AAC PID を全て保持し、要求されたインデックスを選択（見つからない場合は
    主音声にフォールバック）するように変更。
  * 選択されなかった音声 PID のパケットがエンコーダに到達しないように変更。
  * tsreadex の `-b` オプションを `5` から `7` に戻す変更。選択されなかった方の音声
  パケットは既にエンコーダに到達しないようにしているため、副音声非対応環境向けの
  帯域削減という上流の意図を損なうことなく、副音声がまだ存在しない区間で主音声へ
  フォールバックできるようにするための変更です。

## 動作確認状況

build したところ、NVEncC が 9.19 だったので、NVEncC 9.32 を docker cp して動作確認をしました。

### 直接アクセスでの動作確認

KonomiTV クライアントは録画開始マージン分（+2秒）自動的にシークするため、マージン部分からの
継続再生を確認するため、プレイリストの URL に直接アクセスして確認しました。

GET /api/streams/video/{video_id}/{quality}-audio2/playlist?session_id={session_id}

録画マージン部分が主音声のみ、番組本編が主音声・副音声ありのファイルで、副音声を選択した状態で
再生開始から番組本編まで連続再生し、マージン部分では主音声が、番組本編に切り替わった時点で
副音声が再生されることを確認しました。

録画マージン部分が主音声・副音声あり、番組本編が主音声のみのファイルで、副音声を選択した状態で
再生開始から番組本編まで連続再生し、番組本編に切り替わった後も無音にならず、主音声が再生され
続けることを確認しました。

### KonomiTV クライアント

UI を追加せず、KonomiTV/client/src/services/player/PlayerController.ts の build_api_quality() に以下を追加しました。
if (this.playback_mode !== 'Live') {
    api_quality += '-audio2';  // TEMPORARY — force secondary audio for testing, VOD only
}

副音声が正常に再生されることを確認しました。

### 開発中のアプリ

KonomiTV をバックエンドとして利用する開発中のアプリ（未公開）でも確認しました。
動画再生中に主音声・副音声の切り替えを行い、その場で音声が切り替わることを確認しました。

## 追記

なお、このプルリクエストのコードと説明文は Claude（Anthropic）の支援を受けて作成しました。
動作確認は全て実機・実データで行っています。
