### PR TITLE
Fix: [Client][Workers/CaptureCompositor] Comlink へのエクスポート処理の重複を解消

### DIFF
--- a/client/src/workers/CaptureCompositorProxy.ts
+++ b/client/src/workers/CaptureCompositorProxy.ts
@@ -1,10 +1,14 @@
 
-import { ICaptureCompositorConstructor } from '@/workers/CaptureCompositor';
+import * as Comlink from 'comlink';
+
+import type { ICaptureCompositorConstructor } from '@/workers/CaptureCompositor';
 
 
 // CaptureCompositor を Web Worker 上で動作させるためのラッパー
-// Comlink を経由し、Web Worker とメインスレッド間でオブジェクトをやり取りする
-// ラップ元と同じファイルに定義すると Webpack から Circler Dependency として警告されブラウザの挙動が不安定になるため、別ファイルに定義している
-const CaptureCompositorProxy =
-    new ComlinkWorker<ICaptureCompositorConstructor>(new URL('./CaptureCompositor', import.meta.url));
+// CaptureCompositor.ts 側ですでにクラスを Comlink にエクスポートしている。
+// ComlinkWorker を使うとエクスポート処理が重複するため、通常の Worker を Comlink.wrap() に渡す。
+// ラップ元と同じファイルに定義すると Circular Dependency として警告されブラウザの挙動が不安定になるため、別ファイルに定義している
+const CaptureCompositorProxy = Comlink.wrap<ICaptureCompositorConstructor>(
+    new Worker(new URL('./CaptureCompositor.ts', import.meta.url), {type: 'module'}),
+);
 export default CaptureCompositorProxy;


### PR DESCRIPTION
#281 のコミットメッセージをプロジェクトの慣例に合わせて日本語に修正し、再提出します。コードの変更はありません。

## 変更の種類

- [x] 不具合の修正
- [ ] 新しい機能の追加
- [ ] 改善・リファクタリング（機能は追加されないが、動作やコードを改善する破壊的でない変更）

## チェックリスト:

- [x] [開発資料](https://mango-garlic-eff.notion.site/KonomiTV-90f4b25555c14b9ba0cf5498e6feb1c3) と [データベース設計](https://mango-garlic-eff.notion.site/KonomiTV-544e02334c89420fa24804ec70f46b6d) は読みましたか？
- [x] Git のコミットメッセージは開発資料に記載のフォーマットになっていますか？（重要）
- [x] このプロジェクトのコーディング規約に従ったコードになっていますか？
- [x] プルリクエストは master ブランチに送信されていますか？

## 説明

`CaptureCompositor.ts` と `ComlinkWorker` の両方で行われていた、`Comlink` へのエクスポート処理の重複を解消することで、キャプチャ機能の初期化処理でエラーが発生する不具合を修正します。

`CaptureCompositor.ts` 側ですでにクラスを `Comlink` にエクスポートしているため、`CaptureCompositorProxy.ts` では `ComlinkWorker` の代わりに通常の `Worker` を生成し、`Comlink.wrap()` に渡すように変更しました。

`CaptureManager` からのフォント読み込み、インスタンス生成、画像合成の呼び出し方は変更していません。

## 動機とコンテキスト

視聴画面を開くと、キャプチャ機能の初期化中に `Cannot read properties of undefined (reading 'apply')` エラーが発生する不具合を修正します。

`ComlinkWorker` は、`vite-plugin-comlink` によって、対象モジュールのエクスポートを `Comlink` に公開する処理へ変換されます。一方、`CaptureCompositor.ts` 自身も `Comlink.expose(CaptureCompositor)` を呼び出しているため、同じ Web Worker 内でエクスポート処理が重複していました。

この状態で `CaptureManager` の初期化時に `loadFonts()` を呼ぶと、クラス側に加えてモジュール側でも同じ呼び出しが処理されます。モジュール側には `loadFonts()` がないため、再現試験ではエラー応答が先に返り、その後クラス側から成功応答が返りました。

通常の `Worker` を `Comlink.wrap()` に渡すことで、`CaptureCompositor.ts` 側だけが呼び出しを受け付ける構成にします。フォント読み込み自体が失敗した場合のエラーは、引き続き呼び出し側へ返されます。

## 確認内容

修正前の [cc9f340c](https://github.com/libratechw/KonomiTV/commit/cc9f340cde56f9e1343dc212600a78b607a47bd8) では、Linux の Chrome 152 で視聴画面を開いた際に、`Cannot read properties of undefined (reading 'apply')` エラーが再現しました。修正後の [61dad48d](https://github.com/libratechw/KonomiTV/commit/61dad48dced3c7aedaef51dd8dff767cec44c0ec) では、このエラーは発生せず、`CaptureManager` の初期化が完了しました。

提出コミットは [b62f418e](https://github.com/libratechw/KonomiTV/commit/b62f418ebb7abc6e0a7e6c08fadc4c3d75f47249) です。検証対象の [61dad48d](https://github.com/libratechw/KonomiTV/commit/61dad48dced3c7aedaef51dd8dff767cec44c0ec) からコミットメッセージのみ変更しており、ファイル内容と親コミットが同一であることを確認しています。

本番ビルドの Web Worker を Node.js の VM 上で実行し、フォントAPIをテスト用に置き換えた再現試験でも、修正前は `loadFonts()` に対してエラー応答と成功応答が返りましたが、修正後は成功応答だけが返ることを確認しました。フォント読み込み自体が失敗した場合は、修正後もエラー応答が返ります。インスタンス生成も確認しています。

あわせて、修正後の動作とビルドを次の条件で確認しました。

- 対象コミットの本番ビルドを専用の検証サーバーで配信し、以下の実機で、通常・字幕付き・コメント付きキャプチャの保存を手動で確認しました。通常キャプチャは各端末で5回とも成功しました。
  - Lenovo IdeaPad Flex 550 / Windows / Chrome 152.0.7977.77
  - iPhone 15 / iOS 26.6.1 / Safari
- Vite の開発サーバーでも、Linux の Chrome 152 で Web Worker の初期化と 1280×720 の JPEG の5回連続保存を確認しました。ページ例外はありませんでした。開発時のAPI接続先は、検証用ブラウザで専用サーバーへ振り替えています。
- Node.js 20.19.5・Yarn 1.22.22 で、対象コミットの `yarn.lock` を使い、`yarn install --frozen-lockfile --non-interactive` で依存関係を新規インストールしました。`yarn lint`・`yarn typecheck`・`yarn build` はすべて成功し、lint によるソース変更はありませんでした。

## 本PRの変更によらず再現する現象

Safari では、次の現象が修正前の [cc9f340c](https://github.com/libratechw/KonomiTV/commit/cc9f340cde56f9e1343dc212600a78b607a47bd8) と修正後の [61dad48d](https://github.com/libratechw/KonomiTV/commit/61dad48dced3c7aedaef51dd8dff767cec44c0ec) の両方で再現しました。本PRの変更によって発生した現象ではないため、修正には含めていません。

- 字幕なし・字幕ありを両方保存する設定で、キャプチャ一覧には2件追加されるが、ダウンロードされるのは字幕付き画像1枚のみ。
- キャプチャ一覧のサムネイルが「？」表示になる。
- 字幕「♬〜」の「♬」が半角幅のように表示され、「〜」と重なる（再生画面と保存画像の両方）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * キャプチャ合成処理の内部的なワーカー起動方法を更新しました。
  * エンドユーザー向けの機能や操作方法に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->