### PR TITLE
Fix: [Server][Streams/VideoStream] セッションタイムアウト後、/segment や /keep-alive からもセッションを再作成できるように修正

### DIFF
--- a/server/app/routers/VideoStreamsRouter.py
+++ b/server/app/routers/VideoStreamsRouter.py
@@ -162,8 +162,14 @@ async def VideoHLSSegmentAPI(
     """
 
     # 品質とオプション指定に対応する録画視聴セッションを取得
+    ## /playlist を経由しない場合でも、必要な情報 (recorded_program, encoding_options) は揃っているため、
+    ## セッションが SESSION_TIMEOUT で破棄された後の最初のリクエストがこの API であっても再作成できるようにする
+    ## ref: シークの方向によってセッション復帰の可否が変わってしまっていた問題 (巻き戻しでは復帰しないが、10秒送りでは復帰する)
     assert stream_quality.quality != 'original'
-    video_stream = VideoStream(session_id, recorded_program, stream_quality.quality, stream_quality.encoding_options)
+    video_stream = VideoStream(
+        session_id, recorded_program, stream_quality.quality, stream_quality.encoding_options,
+        is_new_session_allowed = True,
+    )
 
     # セグメントを取得（キャッシュキーはブラウザキャッシュ避けのための ID なので特に使わない）
     try:
@@ -292,8 +298,12 @@ async def VideoHLSKeepAliveAPI(
     """
 
     # 品質とオプション指定に対応する録画視聴セッションを取得
+    ## /segment と同様、セッションが破棄された直後の Keep-Alive でも再作成できるようにする (詳細は VideoHLSSegmentAPI 側のコメント参照)
     assert stream_quality.quality != 'original'
-    video_stream = VideoStream(session_id, recorded_program, stream_quality.quality, stream_quality.encoding_options)
+    video_stream = VideoStream(
+        session_id, recorded_program, stream_quality.quality, stream_quality.encoding_options,
+        is_new_session_allowed = True,
+    )
 
     # セッションのアクティブ状態を維持する
     video_stream.keepAlive()

--- a/server/app/streams/VideoStream.py
+++ b/server/app/streams/VideoStream.py
@@ -416,23 +416,13 @@ class VideoStream:
             return (0, 0)
 
 
-    def getVirtualPlaylist(self, cache_key: str | None = None, audio: Literal['primary', 'secondary'] = 'primary') -> str:
+    def _ensureSegmentsInitialized(self) -> None:
         """
-        仮想 HLS M3U8 プレイリストを取得する
-        返却時点では仮想 HLS M3U8 プレイリストに記載されているセグメントのデータは存在せず (「仮想」のゆえん)、随時エンコードされる
-
-        Args:
-            cache_key (str | None): キャッシュ制御用のキー (None の場合は新しいキーを生成する)
-            audio (Literal['primary', 'secondary']): 音声トラック
-
-        Returns:
-            str: 仮想 HLS M3U8 プレイリスト
+        HLS セグメントリスト (self._segments) がまだ空の場合、録画時間とフレームレートから仮想セグメントを作成する
+        getVirtualPlaylist() だけでなく getSegment() からも呼び出されることを想定している
+        ## /playlist を経由せずにセッションが (再) 作成された場合でも、self._segments が必ず初期化された状態になることを保証する
         """
 
-        # セッションのアクティブ状態を維持する
-        self.keepAlive()
-
-        # まだ HLS セグメントリストが空なら、録画時間とフレームレートから仮想セグメントを作成する
         if len(self._segments) == 0:
             segment_count = max(1, math.ceil(self.recorded_program.recorded_video.duration / self._segment_duration_seconds))
             for segment_sequence in range(segment_count):
@@ -453,6 +443,26 @@ class VideoStream:
                 f'{self.log_prefix} Total {len(self._segments)} virtual segments '
                 f'(segment_duration: {self._segment_duration_seconds:.6f}s).'
             )
+
+
+    def getVirtualPlaylist(self, cache_key: str | None = None, audio: Literal['primary', 'secondary'] = 'primary') -> str:
+        """
+        仮想 HLS M3U8 プレイリストを取得する
+        返却時点では仮想 HLS M3U8 プレイリストに記載されているセグメントのデータは存在せず (「仮想」のゆえん)、随時エンコードされる
+
+        Args:
+            cache_key (str | None): キャッシュ制御用のキー (None の場合は新しいキーを生成する)
+            audio (Literal['primary', 'secondary']): 音声トラック
+
+        Returns:
+            str: 仮想 HLS M3U8 プレイリスト
+        """
+
+        # セッションのアクティブ状態を維持する
+        self.keepAlive()
+
+        # まだ HLS セグメントリストが空なら、録画時間とフレームレートから仮想セグメントを作成する
+        self._ensureSegmentsInitialized()
 
         # キャッシュキーが指定されていない場合は UUID の - で区切って一番左側のみを使う
         if cache_key is None:
@@ -772,6 +782,9 @@ class VideoStream:
 
         # セッションのアクティブ状態を維持する
         self.keepAlive()
+
+        # /playlist を経由せずにセッションが (再) 作成された場合に備え、セグメントリストが未初期化なら初期化する
+        self._ensureSegmentsInitialized()
 
         # 終了処理と競合した要求は、破棄予定のセグメントやエンコーダーへ触れず終了する
         if self._is_destroyed is True:


### PR DESCRIPTION
## 変更の種類
<!-- このプルリクエストではどのような変更が行われますか？ 該当するすべてのボックスに「x」を入力してください。 -->
- [x] 不具合の修正
- [ ] 新しい機能の追加
- [ ] 改善・リファクタリング（機能は追加されないが、動作やコードを改善する破壊的でない変更）

## チェックリスト:
<!-- 以下のすべての点に目を通し、該当するすべてのボックスに「x」を入力してください。 -->
- [x] [開発資料](https://mango-garlic-eff.notion.site/KonomiTV-90f4b25555c14b9ba0cf5498e6feb1c3) と [データベース設計](https://mango-garlic-eff.notion.site/KonomiTV-544e02334c89420fa24804ec70f46b6d) は読みましたか？
- [x] Git のコミットメッセージは開発資料に記載のフォーマットになっていますか？（重要）
- [x] このプロジェクトのコーディング規約に従ったコードになっていますか？
- [x] プルリクエストは master ブランチに送信されていますか？

## 説明
<!-- このプルリクエストでの変更点を詳しく説明してください。 -->

録画再生セッションが `SESSION_TIMEOUT` (10秒) でタイムアウトした後、`/segment`
および `/keep-alive` エンドポイント経由ではセッションを再作成できず、
`/playlist` エンドポイント経由でのみ再作成できていた非対称な挙動を修正しました。

* `VideoStreamsRouter.py` の `VideoHLSSegmentAPI` と `VideoHLSKeepAliveAPI` の
  両方で `is_new_session_allowed=True` を渡すようにしました。両エンドポイントも
  `/playlist` と同じ `recorded_program` / `stream_quality.encoding_options` を
  依存性注入で取得できており、セッション再作成に必要な情報自体は揃っています。
* `VideoStream.py` の `self._segments` (仮想セグメントリスト) 初期化処理を
  `getVirtualPlaylist()` から `_ensureSegmentsInitialized()` として切り出し、
  `getVirtualPlaylist()` と `getSegment()` の両方から呼び出すようにしました。
  これにより、`/playlist` を経由せずにセッションが (再) 作成された場合でも
  `self._segments` が正しく初期化されます。

`VideoStream.__new__()` は async 関数ではない (`await` を含まない) ため、
複数リクエストがほぼ同時にセッション再作成を試みても、インスタンス生成の
チェック・登録処理自体はイベントループによって中断されず、競合の心配はありません。

## 動機とコンテキスト
<!-- この変更はなぜ必要ですか？どのような問題が解決されますか？ -->
<!-- この変更で未解決の Issue が修正される場合は、ここにリンクを貼ってください。 -->

主にモバイル通信環境で低ビットレート (240p) で録画番組を視聴していると、
再生が頻繁に先に進まなくなる問題に以前から悩まされていました。
先に進まなくなると、10秒早戻りボタンで再生は10秒前から再開するも、最初に詰まった位置から先には再生は進まず、
10秒早送りボタンを押さないと再生が先に進まないという症状に悩まされていました。

副音声機能の動作確認を行っていた際、この現象の再現ログを取得し、解析を行いました。

セッションが `SESSION_TIMEOUT` (10秒) の無操作でタイムアウトした後、巻き戻し
操作を行った際の実際のログは以下の通りです。

    [21:04:50.335] INFO:  Streaming Session Finished.
    [21:04:50.343] ERROR: Session does not exist.
    [21:04:50.343] INFO:  PUT .../keep-alive?session_id=... 422
    [21:04:52.467] ERROR: Session does not exist.
    [21:04:52.467] INFO:  GET .../segment?session_id=...&sequence=46... 422
    (以降、同じ sequence への再試行と keep-alive の 422 が約100秒間、
      指数バックオフで繰り返される。/playlist へのリクエストは一度も
      発生せず、セッションは復帰しないまま失敗し続ける)

10秒早送りボタンを押した場合は、以下の通り即座に復帰します。

    [21:06:31.058] INFO: Streaming Session Started.
    [21:06:31.058] INFO: GET .../playlist?session_id=...&type=master... 200 OK
    [21:06:31.099] DEBUG: [Segment 47] Segment source position resolved from
                   segment_map. [elapsed: 0.0ms]

`VideoStreamsRouter.py` を確認したところ、`is_new_session_allowed=True` が
渡されているのは `/playlist` エンドポイントのみで、`/segment` と
`/keep-alive` には渡されていませんでした。巻き戻しはプレイヤーが既に読み込み
済みのプレイリスト内の別セグメントを `/segment` で要求するだけで `/playlist`
を再取得しないため、セッションが一度破棄されると、巻き戻しでは永久に復帰
できなくなっていました。一方 10秒送りは未取得の範囲を要求することになり、
結果的に `/playlist` の再取得が発生するため、たまたま復帰できていたようです。

なお、単純に `is_new_session_allowed=True` を `/segment` 側にも渡すだけでは
不十分でした。`self._segments` は `__new__()` 時点では空のままで、これまで
`getVirtualPlaylist()` の呼び出し時にのみ初期化されていたため、`/segment`
経由でセッションが (再) 作成された場合は `self._segments` が空のまま
`getSegment()` が呼ばれてしまいます。そのため、初期化処理を切り出して両方の
メソッドから呼び出すようにしました。

### 変更したファイル

* `server/app/routers/VideoStreamsRouter.py`
  * `VideoHLSSegmentAPI` の `VideoStream()` 呼び出しに `is_new_session_allowed=True`
    を追加。
  * `VideoHLSKeepAliveAPI` の `VideoStream()` 呼び出しにも同様に追加。

* `server/app/streams/VideoStream.py`
  * `getVirtualPlaylist()` 内の仮想セグメントリスト初期化処理を
    `_ensureSegmentsInitialized()` として切り出し。
  * `getSegment()` の冒頭、`keepAlive()` の直後に `_ensureSegmentsInitialized()`
    の呼び出しを追加。

## 動作確認状況

### KonomiTV クライアント

60分程度の録画番組を、実際の KonomiTV クライアント (Chrome / Safari) で
2時間以上ループ再生し続け、セッションタイムアウトからの自然な復帰が
`/keep-alive` 経由でエラーなく発生することを確認しました。

    [Video: 19533/.../240p] Streaming Session Finished.
    (約5秒後)
    [Video: 19533/.../240p] Streaming Session Started.
    PUT .../keep-alive?session_id=... 204 No Content
    [Segment 14] Segment source position resolved from segment_map. [elapsed: 0.0ms]

パッチ適用前は同一構成で `Session does not exist` → 422 が繰り返し発生して
いた状況です。

### 開発中のアプリ (自作 iOS クライアント)

KonomiTV をバックエンドとして利用する開発中のアプリ (まだ公開まで至っていません) で、同じ動画・
画質でパッチ適用前後を比較しました。
(開発中のアプリでは元々、再生が引っかかることがあっても軽微で再生が詰まることはありませんでした)

パッチ適用前は、セッションタイムアウト後の `/segment` 経由での復帰が
`Session does not exist` で失敗していました。クライアント側に再接続ロジックを
実装済みのため再生自体は継続しましたが、再接続時に数十秒のスタッター
(映像が一瞬止まって再開する) が発生していました。

パッチ適用後は、同じ再接続パターン (同一 session_id を再利用した `/segment`
経由での復帰) でもエラーが一切発生せず、スムーズに再生が継続することを
確認しました。

    # パッチ適用前
    [Video: 19533/.../240p] Streaming Session Finished.
    (約5.5分後)
    ERROR: Session does not exist.
    GET .../segment?session_id=...&sequence=68... 422
    (約50秒後)
    Streaming Session Started.
    GET .../playlist?session_id=... 200 OK

    # パッチ適用後
    [Video: 19533/.../240p] Streaming Session Finished.
    (約5.6分後)
    Streaming Session Started.
    GET .../segment?session_id=...&sequence=72... 200 OK
    (/playlist へのリクエストなし)

### 実際の通勤時での検証 (電車内・地下鉄区間を含む)

上記に加えて、実際に電車で移動しながら 240p で約25分間視聴し、通信環境が
不安定な状況での挙動も確認しました。セッションが自然にタイムアウトする場面が
4回発生し、そのうち最も長いものは約70秒の通信断でしたが、いずれもエラーは
一切発生せず、`/keep-alive` 経由・`/segment` 経由の両方で復帰しました。

    [08:54:08.569] INFO: Streaming Session Finished.
    (約70秒後、実際のトンネル区間と思われる通信断)
    [08:55:18.972] INFO: Streaming Session Started.
    [08:55:18.972] INFO: Total 456 virtual segments (segment_duration: 6.006000s).
    [08:55:18.972] DEBUG: [Segment 172] Segment source position resolved from
                   segment_map. [elapsed: 0.0ms]
    (この間 /playlist へのリクエストは一度も発生せず、/segment 経由でそのまま復帰)

体感としても、以前よりも「詰まって進まなくなる」頻度は明らかに減りました。

### コーディング規約・Lint

* `python3 -m py_compile` で両ファイルの構文チェック: 問題なし
* `poetry run task lint`: 0 errors, 6 warnings (いずれも今回変更していない
  `app.py` / `FastAPITaskUtil.py` の既存の warning で、今回の変更とは無関係)

## 追記

なお、このプルリクエストのコードと説明文は Claude (Anthropic) の支援を受けて
作成しました。動作確認は全て実機・実データで行っています。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - セッションのタイムアウト後、HLSセグメント取得時やKeep-Alive時にストリーミングセッションを自動的に再作成できるようになりました。
  - シーク方向によってセッションが復帰できない問題を解消しました。
  - プレイリストを経由せずに開始されたセッションでも、セグメント取得時に必要な初期化が行われるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->